### PR TITLE
[changelog] Post-release version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 allow_dirty = True
 
 [bumpversion:file:./changelog.md]

--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -21,7 +21,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/v0.3.0/requirements.txt
+          /workflows/main/requirements.txt
       - name: Run isort
         run: |
           isort .
@@ -57,7 +57,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/v0.3.0/requirements.txt
+          /workflows/main/requirements.txt
       - name: Auto-format Markdown
         run: |
           find ./ -iname "*.md" -exec mdformat --wrap 79 "{}" \;

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -19,7 +19,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/v0.3.0/requirements.txt
+          /workflows/main/requirements.txt
       - name: Minor version bump
         run: |
           bumpversion --verbose minor
@@ -73,7 +73,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/v0.3.0/requirements.txt
+          /workflows/main/requirements.txt
       - name: Major version bump
         run: |
           bumpversion --verbose major
@@ -127,7 +127,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/v0.3.0/requirements.txt
+          /workflows/main/requirements.txt
       - name: Extract current version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions
@@ -205,7 +205,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/v0.3.0/requirements.txt
+          /workflows/main/requirements.txt
       - name: Extract current version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/v0.3.0/requirements.txt
+          /workflows/main/requirements.txt
       - name: Run Pylint
         if: hashFiles('**/*.py')
         # Docs:
@@ -71,7 +71,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/v0.3.0/requirements.txt
+          /workflows/main/requirements.txt
       - name: Run yamllint
         run: |
           yamllint --strict --format github .

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.1 (unreleased)](https://github.com/kdeldycke/workflows/compare/v0.3.0...main)
+
+```{{important}}
+This version is not released yet and is under active development.
+```
+
 ## [0.3.0 (2021-12-16)](https://github.com/kdeldycke/workflows/compare/v0.2.0...v0.3.0)
 
 - Add a reuseable workflow to fix typos.


### PR DESCRIPTION
Ready to be merged into `main` branch right after a new release has been tagged.

[Auto-generated on run `#1595967090`](https://github.com/kdeldycke/workflows/actions/runs/1595967090) by `post-release-version-bump` job from [`changelog.yaml`](https://github.com/kdeldycke/workflows/blob/c494f7bdd92998da2ae8dff353ea1905f66b0607/.github/workflows/changelog.yaml) workflow.