### PR TITLE
[changelog] Post-release version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 allow_dirty = True
 
 [bumpversion:file:./changelog.md]

--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Black and isort
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
       - name: Run isort
         run: |
           isort .
@@ -55,7 +55,7 @@ jobs:
       - name: Install mdformat
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
       - name: Auto-format Markdown
         run: |
           find ./ -iname "*.md" -exec mdformat --wrap 79 "{}" \;

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
       - name: Minor version bump
         run: |
           bumpversion --verbose minor
@@ -71,7 +71,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
       - name: Major version bump
         run: |
           bumpversion --verbose major
@@ -124,7 +124,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
       - name: Extract current version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions
@@ -201,7 +201,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
       - name: Extract current version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions
@@ -226,7 +226,7 @@ jobs:
       - name: Add new changelog entry
         run: >
           python -c "$(curl -fsSL
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/.github/update_changelog.py)"
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/update_changelog.py)"
       - name: Version bump
         run: |
           bumpversion --verbose patch

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Generate .mailmap
         run: >
           python -c "$(curl -fsSL
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/.github/update_mailmap.py)"
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/update_mailmap.py)"
       - uses: peter-evans/create-pull-request@v3.12.0
         with:
           author: >

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Pylint
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
       - name: Run Pylint
         if: hashFiles('**/*.py')
         # Docs:
@@ -69,7 +69,7 @@ jobs:
       - name: Install yamllint
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.1/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
       - name: Run yamllint
         run: |
           yamllint --strict --format github .

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.2 (unreleased)](https://github.com/kdeldycke/workflows/compare/v0.3.1...main)
+
+```{{important}}
+This version is not released yet and is under active development.
+```
+
 ## [0.3.1 (2021-12-23)](https://github.com/kdeldycke/workflows/compare/v0.3.0...v0.3.1)
 
 - Hard-code tagged version for executed Python script.


### PR DESCRIPTION
Ready to be merged into `main` branch right after a new release has been tagged.

[Auto-generated on run `#1616970948`](https://github.com/kdeldycke/workflows/actions/runs/1616970948) by `post-release-version-bump` job from [`changelog.yaml`](https://github.com/kdeldycke/workflows/blob/610c971e7660a921ca4db7ea278998e75d6aadd5/.github/workflows/changelog.yaml) workflow.