### PR TITLE
[changelog] Release v0.3.2

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -21,7 +21,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/requirements.txt
+          /workflows/v0.3.2/requirements.txt
       - name: Run isort
         run: |
           isort .
@@ -54,7 +54,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/requirements.txt
+          /workflows/v0.3.2/requirements.txt
       - name: Auto-format Markdown
         run: |
           find ./ -iname "*.md" -exec mdformat --wrap 79 "{}" \;

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,7 +29,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/requirements.txt
+          /workflows/v0.3.2/requirements.txt
       - name: Minor version bump
         run: |
           bumpversion --verbose minor
@@ -82,7 +82,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/requirements.txt
+          /workflows/v0.3.2/requirements.txt
       - name: Major version bump
         run: |
           bumpversion --verbose major
@@ -133,7 +133,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/requirements.txt
+          /workflows/v0.3.2/requirements.txt
       - name: Extract current version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions
@@ -210,7 +210,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/requirements.txt
+          /workflows/v0.3.2/requirements.txt
       - name: Extract current version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions
@@ -236,7 +236,7 @@ jobs:
         run: >
           python -c "$(curl -fsSL
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/.github/update_changelog.py)"
+          /workflows/v0.3.2/.github/update_changelog.py)"
       - name: Version bump
         run: |
           bumpversion --verbose patch

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -67,7 +67,7 @@ jobs:
         run: >
           python -c "$(curl -fsSL
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/.github/update_mailmap.py)"
+          /workflows/v0.3.2/.github/update_mailmap.py)"
       - uses: peter-evans/create-pull-request@v3.12.0
         with:
           assignees: ${{ github.actor }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/requirements.txt
+          /workflows/v0.3.2/requirements.txt
       - name: Run Pylint
         if: hashFiles('**/*.py')
         # Docs:
@@ -81,7 +81,7 @@ jobs:
         run: >
           python -m pip install --requirement
           https://raw.githubusercontent.com/kdeldycke\
-          /workflows/main/requirements.txt
+          /workflows/v0.3.2/requirements.txt
       - name: Run yamllint
         run: |
           yamllint --strict --format github .

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,6 @@
 # Changelog
 
-## [0.3.2 (unreleased)](https://github.com/kdeldycke/workflows/compare/v0.3.1...main)
-
-```{{important}}
-This version is not released yet and is under active development.
-```
+## [0.3.2 (2021-12-30)](https://github.com/kdeldycke/workflows/compare/v0.3.1...v0.3.2)
 
 - Refresh every day the date in `prepare-release` job.
 - Skip linting on `prepare-release` job as it does not points to tagged URLs


### PR DESCRIPTION
Ready to be merged into `main` branch and then tagged as a new release.

[Auto-generated on run `#1637897822`](https://github.com/kdeldycke/workflows/actions/runs/1637897822) by `prepare-release` job from [`changelog.yaml`](https://github.com/kdeldycke/workflows/blob/82919b24e7916901568424d636f5b8d08380b163/.github/workflows/changelog.yaml) workflow.