### PR TITLE
[changelog] Release v0.3.4

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Black and isort
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/requirements.txt
       - name: Run isort
         run: |
           isort .
@@ -52,7 +52,7 @@ jobs:
       - name: Install mdformat
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/requirements.txt
       - name: Auto-format Markdown
         run: |
           find ./ -iname "*.md" -exec mdformat --wrap 79 "{}" \;

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/requirements.txt
       - name: Minor version bump
         run: |
           bumpversion --verbose minor
@@ -80,7 +80,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/requirements.txt
       - name: Major version bump
         run: |
           bumpversion --verbose major
@@ -130,7 +130,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/requirements.txt
       - name: Extract current version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Generate .mailmap
         run: >
           python -c "$(curl -fsSL
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/update_mailmap.py)"
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/.github/update_mailmap.py)"
       - uses: peter-evans/create-pull-request@v3.12.0
         with:
           assignees: ${{ github.actor }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Pylint
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/requirements.txt
       - name: Run Pylint
         if: hashFiles('**/*.py')
         # Docs:
@@ -79,7 +79,7 @@ jobs:
       - name: Install yamllint
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/requirements.txt
       - name: Run yamllint
         run: |
           yamllint --strict --config-data "{rules: {line-length: {max: 120}}}" --format github .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/requirements.txt
       - name: Extract current version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions
@@ -78,7 +78,7 @@ jobs:
       - name: Add new changelog entry
         run: >
           python -c "$(curl -fsSL
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/update_changelog.py)"
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.3.4/.github/update_changelog.py)"
       - name: Version bump
         run: |
           bumpversion --verbose patch

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,6 @@
 # Changelog
 
-## [0.3.4 (unreleased)](https://github.com/kdeldycke/workflows/compare/v0.3.3...main)
-
-```{{important}}
-This version is not released yet and is under active development.
-```
+## [0.3.4 (2021-12-31)](https://github.com/kdeldycke/workflows/compare/v0.3.3...v0.3.4)
 
 - Chain `post-release-version-bump` job with automatic git tagging.
 - Auto-commit `post-release-version-bump` results.


### PR DESCRIPTION
This PR is ready to be merged into [`main`](https://github.com/kdeldycke/workflows/tree/main) branch.

The [merge event will trigger via `release.yaml`](https://github.com/kdeldycke/workflows/blob/516104a22a1dfe07c5dee47a06731c597b169219/.github/workflows/release.yaml):

- the creation of a `v0.3.4` tag in Git tree
- the publication of a GitHub release
- the auto-push of a post-release version bump commit

<details><summary>Action source:</summary>

This PR has been [auto-generated on run `#1641246434`](https://github.com/kdeldycke/workflows/actions/runs/1641246434) by `prepare-release` job from [`changelog.yaml`](https://github.com/kdeldycke/workflows/blob/516104a22a1dfe07c5dee47a06731c597b169219/.github/workflows/changelog.yaml) workflow.

</details>