### PR TITLE
[changelog] Release v0.4.0

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Black and isort
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.0/requirements.txt
       - name: Run isort
         run: |
           isort .
@@ -52,7 +52,7 @@ jobs:
       - name: Install mdformat
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.0/requirements.txt
       - name: Auto-format Markdown
         run: |
           find ./ -iname "*.md" -exec mdformat --wrap 79 "{}" \;

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.0/requirements.txt
       - name: ${{ matrix.part }} version bump
         run: |
           bumpversion --verbose ${{ matrix.part }}
@@ -84,7 +84,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.0/requirements.txt
       - name: Extract current version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Generate .mailmap
         run: >
           python -c "$(curl -fsSL
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/update_mailmap.py)"
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.0/.github/update_mailmap.py)"
       - uses: peter-evans/create-pull-request@v3.12.0
         with:
           assignees: ${{ github.actor }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Pylint
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.0/requirements.txt
       - name: Run Pylint
         if: hashFiles('**/*.py')
         # Docs:
@@ -79,7 +79,7 @@ jobs:
       - name: Install yamllint
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.0/requirements.txt
       - name: Run yamllint
         run: |
           yamllint --strict --config-data "{rules: {line-length: {max: 120}}}" --format github .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.0/requirements.txt
       - name: Re-target main branch in workflows
         run: >
           DEFAULT_BRANCH="main" && bumpversion --verbose --no-configured-files
@@ -67,7 +67,7 @@ jobs:
       - name: Add new changelog entry
         run: >
           python -c "$(curl -fsSL
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/update_changelog.py)"
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.0/.github/update_changelog.py)"
       - name: Version bump
         run: |
           bumpversion --verbose patch

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,6 @@
 # Changelog
 
-## [0.4.0 (unreleased)](https://github.com/kdeldycke/workflows/compare/v0.3.5...main)
-
-```{{important}}
-This version is not released yet and is under active development.
-```
+## [0.4.0 (2021-12-31)](https://github.com/kdeldycke/workflows/compare/v0.3.5...v0.4.0)
 
 - Factorize version increment jobs.
 


### PR DESCRIPTION
This PR is ready to be merged into [`main`](https://github.com/kdeldycke/workflows/tree/main) branch.

The [merge event will trigger via `release.yaml`](https://github.com/kdeldycke/workflows/blob/e3d5f88ad0f9e2a62ef89b11b8aac49c08aaec7b/.github/workflows/release.yaml):

- the creation of a `v0.4.0` tag in Git tree
- the publication of a GitHub release
- the auto-push of a post-release version bump commit

<details><summary>Action source:</summary>

This PR has been [auto-generated on run `#1641377552`](https://github.com/kdeldycke/workflows/actions/runs/1641377552) by `prepare-release` job from [`changelog.yaml`](https://github.com/kdeldycke/workflows/blob/e3d5f88ad0f9e2a62ef89b11b8aac49c08aaec7b/.github/workflows/changelog.yaml) workflow.

</details>