### PR TITLE
[changelog] Release v0.4.8

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Black and isort
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.8/requirements.txt
       - name: Run isort
         run: |
           isort .
@@ -56,7 +56,7 @@ jobs:
       - name: Install mdformat
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.8/requirements.txt
       - name: Auto-format Markdown
         run: |
           find ./ -iname "*.md" -exec mdformat --wrap 79 "{}" \;

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.8/requirements.txt
       - name: ${{ matrix.part }} version bump
         run: |
           bumpversion --verbose ${{ matrix.part }}
@@ -85,7 +85,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.8/requirements.txt
       - name: Extract version
         id: get_version
         # Docs: https://docs.github.com/en/actions/learn-github-actions

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Generate .mailmap
         run: >
           python -c "$(curl -fsSL
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/update_mailmap.py)"
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.8/.github/update_mailmap.py)"
       - uses: peter-evans/create-pull-request@v3.12.0
         with:
           assignees: ${{ github.actor }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Pylint
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.8/requirements.txt
       - name: Run Pylint
         if: hashFiles('**/*.py')
         # Docs:
@@ -76,7 +76,7 @@ jobs:
       - name: Install yamllint
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.8/requirements.txt
       - name: Run yamllint
         run: |
           yamllint --strict --config-data "{rules: {line-length: {max: 120}}}" --format github .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Install bumpversion
         run: >
           python -m pip install --requirement
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/requirements.txt
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.8/requirements.txt
       - name: Re-target main branch in workflows
         # This step is only used in the original repository to automate remote URL tagging.
         if: github.repository == 'kdeldycke/workflows'
@@ -82,7 +82,7 @@ jobs:
       - name: Add new changelog entry
         run: >
           python -c "$(curl -fsSL
-          https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/update_changelog.py)"
+          https://raw.githubusercontent.com/kdeldycke/workflows/v0.4.8/.github/update_changelog.py)"
       - name: Version bump
         run: |
           bumpversion --verbose patch

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,6 @@
 # Changelog
 
-## [0.4.8 (unreleased)](https://github.com/kdeldycke/workflows/compare/v0.4.7...main)
-
-```{{important}}
-This version is not released yet and is under active development.
-```
+## [0.4.8 (2022-01-04)](https://github.com/kdeldycke/workflows/compare/v0.4.7...v0.4.8)
 
 - Use more recent `calibreapp/image-actions` action.
 - Remove unused custom variable for reuseable GitHub release job.


### PR DESCRIPTION
This PR is ready to be merged. The merge event will trigger[^1] the:

1. creation of a `v0.4.8` tag on [`main`](https://github.com/kdeldycke/workflows/tree/main) branch
1. publication of a GitHub release
1. auto-push of a post-release version bump commit

[^1]: as [defined by `release.yaml`](https://github.com/kdeldycke/workflows/blob/e1a16d7aae210769c93fabdbfde7c7cdfcb04739/.github/workflows/release.yaml).

<details><summary><code>Workflow metadata</code></summary>

> [Auto-generated on run `#1654380866`](https://github.com/kdeldycke/workflows/actions/runs/1654380866) by `prepare-release` job from [`changelog.yaml`](https://github.com/kdeldycke/workflows/blob/e1a16d7aae210769c93fabdbfde7c7cdfcb04739/.github/workflows/changelog.yaml) workflow.

</details>