### PR TITLE
Freeze docformatter at 1.6.0.rc1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ bump2version == 1.0.1
 check-wheel-contents == 0.4.0
 # Skip docformatter 1.5.x series which struggles with long URLs.
 # See: https://github.com/PyCQA/docformatter/issues/140
-docformatter != 1.5.*
+docformatter == 1.6.0.rc1
 isort == 5.11.4
 # https://mdformat.readthedocs.io/en/stable/users/plugins.html
 mdformat == 0.7.16


### PR DESCRIPTION
As it fixes https://github.com/PyCQA/docformatter/issues/140