### PR TITLE
Quiet pylint and mypy

### DIFF
--- a/.github/metadata.py
+++ b/.github/metadata.py
@@ -513,7 +513,7 @@ class Metadata:
         """
         config = get_configuration(find_config_file())
         config_dict = config.model_dump()
-        return resolve_name(config_dict, "current_version")
+        return str(resolve_name(config_dict, "current_version"))
 
     @cached_property
     def current_version(self) -> str | None:
@@ -526,9 +526,7 @@ class Metadata:
             details = self.new_commits_matrix.get("include")
             if details:
                 version = details[0].get("current_version")  # type: ignore[union-attr]
-        if not version:
-            return None
-        return str(version)
+        return version
 
     @cached_property
     def released_version(self) -> str | None:
@@ -840,8 +838,9 @@ class Metadata:
         # Generate a link to the version of the package published on PyPi.
         pypi_link = ""
         if self.package_name:
-            pypi_link = f"[🐍 Available on PyPi](https://pypi.org/project/{
-                                                self.package_name}/{version})."
+            pypi_link = (
+                f"[🐍 Available on PyPi](https://pypi.org/project/{self.package_name}/{version})."
+            )
 
         # Assemble the release notes.
         return f"{changes}\n\n{pypi_link}".strip()

--- a/.github/metadata.py
+++ b/.github/metadata.py
@@ -527,7 +527,7 @@ class Metadata:
             if details:
                 version = details[0].get("current_version")  # type: ignore[union-attr]
         if not version:
-          return None
+            return None
         return str(version)
 
     @cached_property

--- a/.github/metadata.py
+++ b/.github/metadata.py
@@ -525,8 +525,10 @@ class Metadata:
         if self.new_commits_matrix:
             details = self.new_commits_matrix.get("include")
             if details:
-                version = str(details[0].get("current_version"))  # type: ignore[union-attr]
-        return version
+                version = details[0].get("current_version")  # type: ignore[union-attr]
+        if not version:
+          return None
+        return str(version)
 
     @cached_property
     def released_version(self) -> str | None:

--- a/.github/metadata.py
+++ b/.github/metadata.py
@@ -826,7 +826,7 @@ class Metadata:
         changes = ""
         match = re.search(
             rf"^##(?P<title>.+{escape(version)} .+?)\n(?P<changes>.*?)\n##",
-            Path("./changelog.md").read_text(),
+            Path("./changelog.md").read_text(encoding="utf-8"),
             flags=re.MULTILINE | re.DOTALL,
         )
         if match:

--- a/.github/metadata.py
+++ b/.github/metadata.py
@@ -457,7 +457,7 @@ class Metadata:
         - `--target-version py311`
         - `--target-version py312`
 
-        As mentionned in Black usage, you should `include all Python versions that you
+        As mentioned in Black usage, you should `include all Python versions that you
         want your code to run under
         <https://github.com/psf/black/issues/751#issuecomment-473066811>`_.
         """

--- a/.github/metadata.py
+++ b/.github/metadata.py
@@ -525,7 +525,7 @@ class Metadata:
         if self.new_commits_matrix:
             details = self.new_commits_matrix.get("include")
             if details:
-                version = details[0].get("current_version")  # type: ignore[union-attr]
+                version = str(details[0].get("current_version"))  # type: ignore[union-attr]
         return version
 
     @cached_property

--- a/changelog.md
+++ b/changelog.md
@@ -33,7 +33,7 @@ This version is not released yet and is under active development.
 
 ## [2.23.0 (2024-01-05)](https://github.com/kdeldycke/workflows/compare/v2.22.0...v2.23.0)
 
-- Produce GitHub release notes dynamiccaly.
+- Produce GitHub release notes dynamically.
 - Augment all commits matrix with current version from `bump-my-version`.
 - Use new artifact features and scripts.
 


### PR DESCRIPTION
Quiets pylint's
```
  .github/metadata.py:832:12: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
```
and mypy's
```
  .github/metadata.py: note: In member "get_current_version" of class "Metadata":
  .github/metadata.py:519: error: Returning Any from function declared to return "str"  [no-any-return]
```