### PR TITLE
fix: quiet mypy warning

### DIFF
--- a/.github/metadata.py
+++ b/.github/metadata.py
@@ -378,7 +378,7 @@ class Metadata:
     def is_poetry_project(self) -> bool:
         """Returns true if project relies on Poetry."""
         if self.pyproject_path.exists() and self.pyproject_path.is_file():
-            return self.pyproject.is_poetry_project()
+            return bool(self.pyproject.is_poetry_project())
         return False
 
     @cached_property


### PR DESCRIPTION
This harmless cast fixes this warning I'm getting with mypy 1.9.0:
```
  .github/metadata.py: note: In member "is_poetry_project" of class "Metadata":
  .github/metadata.py:381: error: Returning Any from function declared to return "bool"  [no-any-return]
```
in my megalinter action [here](https://github.com/rasa/workflows/actions/runs/9008982705/job/24752248861#step:5:163).

I'm stumped why you don't see this issue as well.