### PR TITLE
[autofix] Typo

### DIFF
--- a/gha_utils/cli.py
+++ b/gha_utils/cli.py
@@ -201,7 +201,7 @@ def mailmap_sync(ctx, source, create_if_missing, destination_mailmap):
     history.
 
     By default the ``.mailmap`` at the root of the repository is read and its content
-    is reused as reference, so identities already gouped in there are preserved and
+    is reused as reference, so identities already grouped in there are preserved and
     used as initial mapping. To which missing contributors are added.
 
     The resulting updated mapping is printed to the console output. So a bare call to


### PR DESCRIPTION
<details><summary><code>Workflow metadata</code></summary>

> [Auto-generated on run `#9935024652`](https://github.com/kdeldycke/workflows/actions/runs/9935024652) by `autofix-typo` job from [`docs.yaml`](https://github.com/kdeldycke/workflows/blob/fecf1417f32195d87416aad3657718eaf6e66bc2/.github/workflows/docs.yaml) workflow.

</details>