### PR TITLE
[autofix] Typo

### DIFF
--- a/gha_utils/cli.py
+++ b/gha_utils/cli.py
@@ -228,7 +228,7 @@ def mailmap_sync(ctx, source, create_if_missing, destination_mailmap):
 
     By default the ``.mailmap`` at the root of the repository is read and its content
     is reused as reference, so identities already aliased in there are preserved and
-    used as initial mapping. Only missing contributors not found in this initial maping
+    used as initial mapping. Only missing contributors not found in this initial mapping
     are added.
 
     The resulting updated mapping is printed to the console output. So a bare call to

--- a/gha_utils/mailmap.py
+++ b/gha_utils/mailmap.py
@@ -82,7 +82,7 @@ class Mailmap:
 
         Each non-empty, non-comment line is considered a mapping entry.
 
-        The preceding lines of a maping entry are kept attached to it as pre-comments,
+        The preceding lines of a mapping entry are kept attached to it as pre-comments,
         so the layout will be preserved on rendering, during which records are sorted.
         """
         logging.debug(f"Parsing:\n{content}")


### PR DESCRIPTION
<details><summary><code>Workflow metadata</code></summary>

> [Auto-generated on run `#9942253716`](https://github.com/kdeldycke/workflows/actions/runs/9942253716) by `autofix-typo` job from [`docs.yaml`](https://github.com/kdeldycke/workflows/blob/96a81c7437ea2737e2a2cf7910d4e529d1c823ec/.github/workflows/docs.yaml) workflow.

</details>