### PR TITLE
[autofix] Typo

### DIFF
--- a/gha_utils/mailmap.py
+++ b/gha_utils/mailmap.py
@@ -128,7 +128,7 @@ class Mailmap:
 
     @cached_property
     def git_contributors(self) -> set[str]:
-        """Returns the set of all constributors found in the Git commit history.
+        """Returns the set of all contributors found in the Git commit history.
 
         No normalization happens: all variations of authors and committers strings
         attached to all commits are considered.


### PR DESCRIPTION
<details><summary><code>Workflow metadata</code></summary>

> [Auto-generated on run `#18252920171`](https://github.com/kdeldycke/workflows/actions/runs/18252920171) by `autofix-typo` job from [`docs.yaml`](https://github.com/kdeldycke/workflows/blob/4d29d506fbe8f7bce798ed6de6ee9b509a4c9a78/.github/workflows/docs.yaml) workflow.

</details>