### PR TITLE
Fix `update-cli-pins` and update to v5.7.1

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Run gha-utils metadata
         id: project-metadata
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' metadata --output "$GITHUB_OUTPUT"
+          uvx --no-progress 'gha-utils==5.7.1' metadata --output "$GITHUB_OUTPUT"
 
   # --- Formatters: rewrite files to enforce canonical style. ---
 
@@ -102,7 +102,7 @@ jobs:
         # Projects with existing ruff config will keep their settings.
         run: |
           uv tool install 'ruff==0.15.0'
-          uvx --no-progress 'gha-utils==5.7.0' bundled init ruff pyproject.toml
+          uvx --no-progress 'gha-utils==5.7.1' bundled init ruff pyproject.toml
       # XXX Ruff is planning to support linting and formatting in one unified command at one point.
       #     See: https://github.com/astral-sh/ruff/issues/8232
       - name: Run Ruff
@@ -360,7 +360,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7.2.1
       - name: Initialize bumpversion config
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' bundled init bumpversion pyproject.toml
+          uvx --no-progress 'gha-utils==5.7.1' bundled init bumpversion pyproject.toml
       - id: pr-metadata
         uses: kdeldycke/workflows/.github/actions/pr-metadata@main
       - uses: peter-evans/create-pull-request@v8.1.0
@@ -386,7 +386,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7.2.1
       - name: Generate .mailmap
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' mailmap-sync --skip-if-missing ./.mailmap
+          uvx --no-progress 'gha-utils==5.7.1' mailmap-sync --skip-if-missing ./.mailmap
       - id: pr-metadata
         uses: kdeldycke/workflows/.github/actions/pr-metadata@main
       - uses: peter-evans/create-pull-request@v8.1.0
@@ -416,7 +416,7 @@ jobs:
       - name: Generate graph
         # Include all dependency groups in the graph with subgraphs.
         run: >
-          uvx --no-progress 'gha-utils==5.7.0' deps-graph
+          uvx --no-progress 'gha-utils==5.7.1' deps-graph
           ${{ needs.project-metadata.outputs.package_name
           && format('--package {0}', needs.project-metadata.outputs.package_name)}}
           --all-groups --all-extras

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Run gha-utils metadata
         id: project-metadata
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' metadata --output "$GITHUB_OUTPUT"
+          uvx --no-progress 'gha-utils==5.7.1' metadata --output "$GITHUB_OUTPUT"
 
   bump-versions:
     needs:
@@ -144,7 +144,7 @@ jobs:
         # Updates changelog and citation dates, comparison URL, and removes warning.
         # Also hard-codes version in workflow URLs for kdeldycke/workflows repository.
         run: >-
-          uvx --no-progress 'gha-utils==5.7.0' release-prep
+          uvx --no-progress 'gha-utils==5.7.1' release-prep
           ${{ github.repository == 'kdeldycke/workflows' && '--update-workflows' || '' }}
       - name: Prepare repository
         run: |
@@ -158,10 +158,10 @@ jobs:
         # This step is only used in the original repository to automate remote URL tagging.
         if: github.repository == 'kdeldycke/workflows'
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' release-prep --post-release --update-workflows
+          uvx --no-progress 'gha-utils==5.7.1' release-prep --post-release --update-workflows
       - name: Add new changelog entry
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' changelog ./changelog.md
+          uvx --no-progress 'gha-utils==5.7.1' changelog ./changelog.md
       - name: Version bump
         run: |
           bump-my-version bump --verbose patch

--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Run gha-utils metadata
         id: project-metadata
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' --verbosity DEBUG metadata --output "$GITHUB_OUTPUT"
+          uvx --no-progress 'gha-utils==5.7.1' --verbosity DEBUG metadata --output "$GITHUB_OUTPUT"
       - name: Extend matrix with ubuntu-slim
         id: extend-matrix
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run gha-utils metadata
         id: project-metadata
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' metadata --output "$GITHUB_OUTPUT"
+          uvx --no-progress 'gha-utils==5.7.1' metadata --output "$GITHUB_OUTPUT"
 
   deploy-docs:
     name: Deploy Sphinx doc
@@ -87,7 +87,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          uvx --no-progress 'gha-utils==5.7.0' sphinx-linkcheck
+          uvx --no-progress 'gha-utils==5.7.1' sphinx-linkcheck
           --output-json ./docs/linkcheck/output.json
           --repo-name "${{ github.event.repository.name }}"
 
@@ -122,7 +122,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          uvx --no-progress 'gha-utils==5.7.0' broken-links
+          uvx --no-progress 'gha-utils==5.7.1' broken-links
           --lychee-exit-code ${{ steps.lychee_run.outputs.exit_code }}
           --body-file ./lychee/out.md
           --repo-name "${{ github.event.repository.name }}"

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -45,7 +45,7 @@ jobs:
           tool: labelmaker@0.6.4
       - name: Dump labels
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' bundled export labels.toml
+          uvx --no-progress 'gha-utils==5.7.1' bundled export labels.toml
       - name: Download extra label files
         if: inputs.extra-label-files
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Run gha-utils metadata
         id: project-metadata
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' metadata --output "$GITHUB_OUTPUT"
+          uvx --no-progress 'gha-utils==5.7.1' metadata --output "$GITHUB_OUTPUT"
 
   file-labeller:
     name: File-based PR labeller
@@ -111,7 +111,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7.2.1
       - name: Dump default rules
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' bundled export labeller-file-based.yaml
+          uvx --no-progress 'gha-utils==5.7.1' bundled export labeller-file-based.yaml
       - name: Extend default rules
         if: inputs.extra-file-rules
         run: |
@@ -137,7 +137,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7.2.1
       - name: Dump default rules
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' bundled export labeller-content-based.yaml
+          uvx --no-progress 'gha-utils==5.7.1' bundled export labeller-content-based.yaml
       - name: Extend default rules
         if: inputs.extra-content-rules
         run: |
@@ -166,4 +166,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' sponsor-label
+          uvx --no-progress 'gha-utils==5.7.1' sponsor-label

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Run gha-utils metadata
         id: project-metadata
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' metadata --output "$GITHUB_OUTPUT"
+          uvx --no-progress 'gha-utils==5.7.1' metadata --output "$GITHUB_OUTPUT"
 
   lint-repo:
     needs:
@@ -54,7 +54,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
-          uvx --no-progress 'gha-utils==5.7.0' lint-repo
+          uvx --no-progress 'gha-utils==5.7.1' lint-repo
           ${{ needs.project-metadata.outputs.package_name &&
           format('--package-name "{0}"', needs.project-metadata.outputs.package_name) || '' }}
           --repo-name "${{ github.event.repository.name }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Run gha-utils metadata
         id: project-metadata
         run: >
-          uvx --no-progress 'gha-utils==5.7.0' metadata
+          uvx --no-progress 'gha-utils==5.7.1' metadata
           ${{ inputs.unstable-targets != null && format('--unstable-targets "{0}"', inputs.unstable-targets) || '' }}
           --output "$GITHUB_OUTPUT"
 
@@ -196,7 +196,7 @@ jobs:
           choco install exiftool --no-progress --yes --retry-count=3
       - name: Verify binary architecture
         run: >
-          uvx --no-progress 'gha-utils==5.7.0'
+          uvx --no-progress 'gha-utils==5.7.1'
           verify-binary --target "${{ matrix.target }}" --binary "${{ matrix.bin_name }}"
       - name: Upload binaries
         uses: actions/upload-artifact@v6.0.0
@@ -235,7 +235,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7.2.1
       - name: Run test plan for binary
         run: >
-          uvx --no-progress 'gha-utils==5.7.0' test-plan
+          uvx --no-progress 'gha-utils==5.7.1' test-plan
           ${{ inputs.timeout != null && format('--timeout {0}', inputs.timeout) || '' }}
           --binary "${{ steps.artifacts.outputs.download-path }}/${{ matrix.bin_name }}"
           --plan-file "${{ env.test-plan-file }}"
@@ -264,7 +264,7 @@ jobs:
         # Idempotent: skips if tag already exists instead of failing. This allows re-running
         # workflows interrupted after tag creation.
         run: >
-          uvx --no-progress 'gha-utils==5.7.0' git-tag
+          uvx --no-progress 'gha-utils==5.7.1' git-tag
           --tag "v${{ matrix.current_version }}"
           --commit "${{ matrix.commit }}"
           --skip-existing
@@ -339,7 +339,7 @@ jobs:
         if: steps.artifacts.outputs.download-path
         id: collect_artifacts
         run: >
-          uvx --no-progress 'gha-utils==5.7.0' collect-artifacts
+          uvx --no-progress 'gha-utils==5.7.1' collect-artifacts
           --download-folder "${{ steps.artifacts.outputs.download-path }}"
           --short-sha "${{ matrix.short_sha }}"
           --nuitka-matrix '${{ needs.project-metadata.outputs.nuitka_matrix }}'
@@ -377,6 +377,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.sha }}
+          # Depth 2 so git-describe can reach the freeze commit's tag from the
+          # unfreeze commit (they are adjacent in the rebase-merged PR).
+          fetch-depth: 2
           fetch-tags: true
       - name: Get latest release version
         id: version

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -57,12 +57,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_UPDATE_GITHUB_PAT || secrets.GITHUB_TOKEN }}
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' check-renovate --format=github --output "$GITHUB_OUTPUT"
+          uvx --no-progress 'gha-utils==5.7.1' check-renovate --format=github --output "$GITHUB_OUTPUT"
 
       - name: Export renovate.json5 if missing
         if: steps.checks.outputs.renovate_config_exists == 'false'
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' bundled export renovate.json5
+          uvx --no-progress 'gha-utils==5.7.1' bundled export renovate.json5
 
       - name: Remove Dependabot config if present
         if: steps.checks.outputs.dependabot_config_path != ''
@@ -92,7 +92,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_UPDATE_GITHUB_PAT || secrets.GITHUB_TOKEN }}
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' check-renovate
+          uvx --no-progress 'gha-utils==5.7.1' check-renovate
 
       - name: Update exclude-newer date if stale
         id: update_date
@@ -100,7 +100,7 @@ jobs:
         # Uses a fixed date (not relative) to prevent uv.lock timestamp churn on every sync.
         # Runs before Renovate so changes are picked up in lock file maintenance.
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' update-exclude-newer --output "$GITHUB_OUTPUT"
+          uvx --no-progress 'gha-utils==5.7.1' update-exclude-newer --output "$GITHUB_OUTPUT"
 
       - name: Commit and push if modified
         if: steps.update_date.outputs.modified == 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,7 +123,7 @@ jobs:
       - name: Run gha-utils metadata
         id: project-metadata
         run: |
-          uvx --no-progress 'gha-utils==5.7.0' metadata --output "$GITHUB_OUTPUT"
+          uvx --no-progress 'gha-utils==5.7.1' metadata --output "$GITHUB_OUTPUT"
 
   validate-arch:
     # Check architecture matches the one expected from the runner image. This is to ensure that the OS does not rely on


### PR DESCRIPTION
## Summary

- Fix shallow clone bug in `update-cli-pins` job: add `fetch-depth: 2` so `git describe` can reach the freeze commit's tag from the unfreeze commit
- Update all `gha-utils==5.7.0` pins to `gha-utils==5.7.1` (what the broken job should have done)

Closes the issue from #2261 where `git describe --tags --abbrev=0` returned empty because the default `fetch-depth: 1` only checked out the unfreeze commit, while the `v5.7.1` tag was on the freeze commit one step back.

## Test plan

- [ ] Verify CI passes with `gha-utils==5.7.1` pins
- [ ] On next release, confirm `update-cli-pins` job correctly detects the version

🤖 Generated with [Claude Code](https://claude.com/claude-code)