### PR TITLE
Replace `pr-metadata` action with `gha-utils==5.8.0 pr-body` CLI

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -110,7 +110,7 @@ jobs:
           ruff check --output-format github
           ruff format --output-format github
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -137,7 +137,7 @@ jobs:
           --expand-tables project.entry-points,project.optional-dependencies,project.urls,project.scripts
           pyproject.toml || true
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -205,7 +205,7 @@ jobs:
           find ./ -type f \( -name 'readme.md' -or -name 'readme.*.md' \) -print
           -exec gawk -i inplace '!/^- \[(Contents|Contributing|Footnotes|Related Lists)\]\(#.+\)$/{print}' "{}" \;
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -237,7 +237,7 @@ jobs:
           --json-parse-allow-trailing-commas=true
           ${{ needs.project-metadata.outputs.json_files }}
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -260,7 +260,7 @@ jobs:
       - name: Remove local typos binary
         run: rm ./typos
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           # We need custom PAT with workflows permissions to fix typos in .github/workflows/*.yaml` files.
@@ -286,9 +286,9 @@ jobs:
         with:
           compressOnly: true
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
-        with:
-          prefix: ${{ steps.image_actions.outputs.markdown }}
+        env:
+          GHA_PR_BODY_PREFIX: ${{ steps.image_actions.outputs.markdown }}
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -342,7 +342,7 @@ jobs:
           ${{ env.gitignore-extra-content }}
           EOF
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -362,7 +362,7 @@ jobs:
         run: |
           uvx --no-progress 'gha-utils==5.7.1' bundled init bumpversion pyproject.toml
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -388,7 +388,7 @@ jobs:
         run: |
           uvx --no-progress 'gha-utils==5.7.1' mailmap-sync --skip-if-missing ./.mailmap
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -422,7 +422,7 @@ jobs:
           --all-groups --all-extras
           --output "${{ env.dependency-graph-output }}"
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -454,7 +454,7 @@ jobs:
             uv --no-progress run --frozen --group docs -- python docs/docs_update.py
           fi
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           assignees: ${{ github.actor }}
@@ -479,12 +479,12 @@ jobs:
           token: ${{ secrets.WORKFLOW_UPDATE_GITHUB_PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
-        with:
-          # Template variables are substituted by the template-sync action.
-          prefix: |
+        # Template variables are substituted by the template-sync action.
+        env:
+          GHA_PR_BODY_PREFIX: |
             Files synced from [`kdeldycke/awesome-template@${TEMPLATE_GIT_HASH}`
             repository](${SOURCE_REPO}/tree/${TEMPLATE_GIT_HASH}).
+        run: uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - name: Sync from template repo
         id: template_sync
         uses: AndreasAugustin/actions-template-sync@v2.5.2

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -105,9 +105,8 @@ jobs:
           echo "new_version=$( bump-my-version show current_version )" | tee -a "$GITHUB_OUTPUT"
       - id: pr-metadata
         if: needs.project-metadata.outputs[format('{0}_bump_allowed', matrix.part)] == 'true'
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
-        with:
-          prefix: |
+        env:
+          GHA_PR_BODY_PREFIX: |
             ### Description
 
             Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the ${{ matrix.part }}
@@ -120,6 +119,8 @@ jobs:
             1. **click `Rebase and merge`** button below
 
             ---
+        run: |
+          uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         if: needs.project-metadata.outputs[format('{0}_bump_allowed', matrix.part)] == 'true'
         with:
@@ -187,9 +188,8 @@ jobs:
           v${{ steps.get_version.outputs.current_version }}
           → v$(bump-my-version show current_version)"
       - id: pr-metadata
-        uses: kdeldycke/workflows/.github/actions/pr-metadata@v5.7.2
-        with:
-          prefix: >
+        env:
+          GHA_PR_BODY_PREFIX: >
             ### Description
 
             This PR is ready to be merged. The [merge event will
@@ -226,6 +226,8 @@ jobs:
               > to refresh this PR manually before merging.
 
             ---
+        run: |
+          uvx --no-progress 'gha-utils==5.8.0' pr-body --output "$GITHUB_OUTPUT"
       - uses: peter-evans/create-pull-request@v8.1.0
         with:
           # We need custom PAT with workflows permission to hard-code version numbers in URLs in

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 
 - Fix stale checkout in `bump-versions` causing merge conflicts after releases.
 - Add `cancel-runs.yaml` workflow to cancel in-progress and queued runs when a PR is closed.
-- Add `gha-utils pr-body` subcommand to generate PR body with workflow metadata. Workflows still use the `pr-metadata` composite action until the next release publishes `gha-utils` to PyPI.
+- Replace `pr-metadata` composite action with `gha-utils pr-body` subcommand to generate PR body with workflow metadata.
 - Remove `update-cli-pins` job from `release.yaml`. Renovate already handles updating `gha-utils` version.
 
 ## [5.7.2 (2026-02-11)](https://github.com/kdeldycke/workflows/compare/v5.7.1...v5.7.2)


### PR DESCRIPTION
## Summary

- Delete the `pr-metadata` composite action (restored temporarily on `main` to unblock CI)
- Switch all workflow `pr-metadata` steps from the action to `uvx 'gha-utils==5.8.0' pr-body`
- Update changelog and test expectations

**Merge after** `gha-utils` 5.8.0 is published to PyPI.

## Test plan

- [ ] Verify `gha-utils` 5.8.0 is available on PyPI before merging
- [ ] After merge, confirm PR-creating jobs (`autofix`, `changelog`) succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)