### PR TITLE
Skip build attestation on fork PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,6 +144,10 @@ jobs:
       - name: Build package
         run: uv --no-progress build
       - name: Generate build attestations
+        # OIDC tokens are not available for fork PRs, skip attestation.
+        if: >-
+          github.event_name != 'pull_request'
+          || !github.event.pull_request.head.repo.fork
         uses: actions/attest-build-provenance@v3.2.0
         with:
           subject-path: ./dist/*


### PR DESCRIPTION
## Summary
- Add `if:` guard to the `build-package` attestation step to skip when running on fork PRs
- OIDC tokens (`id-token: write`) are not available for `pull_request` events from forks — a hard GitHub security restriction
- The step fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` on every fork PR across all downstream callers (e.g. kdeldycke/meta-package-manager#1704)

The other attestation steps are already protected: `compile-binaries` and `create-release` only attest on `refs/heads/main`, and `publish-pypi` depends on `create-tag` which is main-only.

## Test plan
- [ ] Verify fork PRs on downstream repos no longer fail on the attestation step
- [ ] Verify same-repo PRs still generate attestations
- [ ] Verify pushes to `main` still generate attestations