### PR TITLE
Typo

### DIFF
--- a/repomatic/lint_repo.py
+++ b/repomatic/lint_repo.py
@@ -461,7 +461,7 @@ def check_immutable_releases(repo: str) -> tuple[bool | None, str]:
 
     :param repo: Repository in 'owner/repo' format.
     :return: Tuple of (passed_or_None, message). ``None`` means the check
-        could not run (API inaccessible or unparseable).
+        could not run (API inaccessible or unparsable).
     """
     try:
         output = run_gh_command(["api", f"repos/{repo}/immutable-releases"])


### PR DESCRIPTION
### Description

Fixes typos detected by [typos](https://github.com/crate-ci/typos). See the [`fix-typos` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Manage false positives and customize spell-checking rules via [`[tool.typos]`](https://github.com/crate-ci/typos/blob/master/docs/reference.md) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `workflow_dispatch` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`91e62f27`](https://github.com/kdeldycke/repomatic/commit/91e62f27ed0c6165fc3b8e37f4c947befbfdfefb) |
| **Job** | [`fix-typos`](https://github.com/kdeldycke/repomatic/blob/91e62f27ed0c6165fc3b8e37f4c947befbfdfefb/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/91e62f27ed0c6165fc3b8e37f4c947befbfdfefb/.github/workflows/autofix.yaml) |
| **Run** | [#4249.1](https://github.com/kdeldycke/repomatic/actions/runs/24077947788) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.11.0.dev0`