### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,12 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-03T14:44:55.430740014Z"
+exclude-newer = "2026-04-06T04:13:15.314556705Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-click-extra = { timestamp = "2026-04-10T14:44:55.430746205Z", span = "PT0S" }
-repomatic = { timestamp = "2026-04-10T14:44:55.430751866Z", span = "PT0S" }
+click-extra = { timestamp = "2026-04-13T04:13:15.31456465Z", span = "PT0S" }
+repomatic = { timestamp = "2026-04-13T04:13:15.314568457Z", span = "PT0S" }
 
 [[package]]
 name = "aiofiles"
@@ -365,14 +365,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
 ]
 
 [[package]]
@@ -397,15 +397,15 @@ wheels = [
 
 [[package]]
 name = "cloup"
-version = "3.0.8"
+version = "3.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/cf/09a31f0f51b5c8ef2343baf37c35a5feb4f6dfdcbd0592a014baf837f2e4/cloup-3.0.8.tar.gz", hash = "sha256:f91c080a725196ddf74feabd6250266f466e97fc16dfe21a762cf6bc6beb3ecb", size = 229657, upload-time = "2025-08-05T02:25:02.83Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/64/7f0a66021ff81d51859c66adc13f3c71f0306c2f8dfb9877a0694cbada05/cloup-3.0.9.tar.gz", hash = "sha256:519f524d3c64040e49a0866b5fc0bfd6af3eac0d3d6a4b2b50b33ab0247db2d7", size = 229896, upload-time = "2026-04-04T03:53:54.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/0a/494a923f90cd97cdf4fb989cfd06ac0c6745f6dfb8adcef1b7f99d3c7834/cloup-3.0.8-py2.py3-none-any.whl", hash = "sha256:6fe9474dc44fa06f8870e9c797f005de1e3ef891ddc1a9612d9b58598a038323", size = 54647, upload-time = "2025-08-05T02:25:01.536Z" },
+    { url = "https://files.pythonhosted.org/packages/77/15/435bb5a24e3a2dc8c26afedab0c6f0cf4291c66fb99509c168c38eb81135/cloup-3.0.9-py2.py3-none-any.whl", hash = "sha256:c761ef4e975454335d50c0e1eb83595a932735aac06e8955b3ced774bc62ae7b", size = 54724, upload-time = "2026-04-04T03:53:52.909Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-06`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | `8.3.1` -> `8.3.2` | 2026-04-03 |
| [cloup](https://pypi.org/project/cloup/) | `3.0.8` -> `3.0.9` | 2026-04-04 |

### Release notes

<details>
<summary>pallets/click (<code>click</code>)</summary>

#### [`8.3.2`](https://github.com/pallets/click/releases/tag/8.3.2)

This is the Click 8.3.2 fix release, which fixes bugs but does not otherwise change behavior and should not result in breaking changes compared to the latest feature release.

PyPI: https://pypi.org/project/click/8.3.2/
Changes: https://click.palletsprojects.com/page/changes/#version-8-3-2
Milestone: https://redirect.github.com/pallets/click/milestone/29

-   Fix handling of ``flag_value`` when ``is_flag=False`` to allow such options to be
    used without an explicit value. #​3084 #​3152
-   Hide ``Sentinel.UNSET`` values as ``None`` when using ``lookup_default()``.
    #​3136 #​3199 #​3202 #​3209 #​3212 #​3224
-   Prevent ``_NamedTextIOWrapper`` from closing streams owned by ``StreamMixer``.
    #​824 #​2991 #​2993 #​3110 #​3139 #​3140
-   Add comprehensive tests for ``CliRunner`` stream lifecycle, covering
    logging interaction, multi-threaded safety, and sequential invocation
    isolation. Add high-iteration stress tests behind a ``stress`` marker
    with a dedicated CI job. #​3139
-   Fix callable ``flag_value`` being instantiated when used as a default via
    ``default=True``. #​3121 #​3201 #​3213 #​3225

</details>

<details>
<summary>janLuke/cloup (<code>cloup</code>)</summary>

#### [`v3.0.9`](https://github.com/janLuke/cloup/releases/tag/v3.0.9)

<!-- Release notes generated using configuration in .github/release.yaml at v3.0.9 -->

## What's Changed
### Other Changes
* fix for the click.__version__ deprecation warning by @​cav71 in https://redirect.github.com/janluke/cloup/pull/192
* Pin setuptools<81 in docs requirements by @​janluke in https://redirect.github.com/janluke/cloup/pull/197
* Pin setuptools_scm<10 in setup_requires by @​janluke in https://redirect.github.com/janluke/cloup/pull/198

## New Contributors
* @​cav71 made their first contribution in https://redirect.github.com/janluke/cloup/pull/192

**Full Changelog**: https://redirect.github.com/janluke/cloup/compare/v3.0.8...v3.0.9

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`bafc3d51`](https://github.com/kdeldycke/repomatic/commit/bafc3d51c9987aff5cf4738d78fc7fee2cf5ce17) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/bafc3d51c9987aff5cf4738d78fc7fee2cf5ce17/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/bafc3d51c9987aff5cf4738d78fc7fee2cf5ce17/.github/workflows/autofix.yaml) |
| **Run** | [#4312.1](https://github.com/kdeldycke/repomatic/actions/runs/24325295341) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.12.0.dev0`