### PR TITLE
Bump minor version to `v6.13.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`6.12.1.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v6.12.0...main)
+## [`6.13.0.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v6.12.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "repomatic"
-version = "6.12.1.dev0"
+version = "6.13.0.dev0"
 description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 readme = "readme.md"
 keywords = [
@@ -122,7 +122,7 @@ repomatic = "repomatic.__main__:main"
 
 [project.urls]
 "Changelog" = "https://github.com/kdeldycke/repomatic/blob/main/changelog.md"
-"Download" = "https://github.com/kdeldycke/repomatic/releases/tag/v6.12.1.dev0"
+"Download" = "https://github.com/kdeldycke/repomatic/releases/tag/v6.13.0.dev0"
 "Funding" = "https://github.com/sponsors/kdeldycke"
 "Homepage" = "https://github.com/kdeldycke/repomatic"
 "Issues" = "https://github.com/kdeldycke/repomatic/issues"
@@ -241,7 +241,7 @@ run.source = [ "repomatic" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "6.12.1.dev0"
+current_version = "6.13.0.dev0"
 allow_dirty = true
 ignore_missing_files = true
 # Parse versions with an optional .devN suffix (PEP 440).

--- a/repomatic/__init__.py
+++ b/repomatic/__init__.py
@@ -17,5 +17,5 @@
 
 from __future__ import annotations
 
-__version__ = "6.12.1.dev0"
+__version__ = "6.13.0.dev0"
 __git_tag_sha__ = ""

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,12 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-06T04:39:29.771992101Z"
+exclude-newer = "2026-04-06T18:59:50.298509046Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-click-extra = { timestamp = "2026-04-13T04:39:29.772000537Z", span = "PT0S" }
-repomatic = { timestamp = "2026-04-13T04:39:29.772006508Z", span = "PT0S" }
+click-extra = { timestamp = "2026-04-13T18:59:50.298515679Z", span = "PT0S" }
+repomatic = { timestamp = "2026-04-13T18:59:50.298521971Z", span = "PT0S" }
 
 [[package]]
 name = "aiofiles"
@@ -1491,7 +1491,7 @@ wheels = [
 
 [[package]]
 name = "repomatic"
-version = "6.12.1.dev0"
+version = "6.13.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowschangelogyaml-jobs) for details.

### To bump version to `v6.13.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`77dce445`](https://github.com/kdeldycke/repomatic/commit/77dce44553a6198789eea846110beb7cb7dd64e9) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/repomatic/blob/77dce44553a6198789eea846110beb7cb7dd64e9/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/77dce44553a6198789eea846110beb7cb7dd64e9/.github/workflows/changelog.yaml) |
| **Run** | [#3928.1](https://github.com/kdeldycke/repomatic/actions/runs/24361318209) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0.dev0`