### PR TITLE
Fix vulnerable dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ typing = [ "types-boltons>=25.0.0.20250822", "types-pyyaml>=6.0.12.9" ]
 # (sync-uv-lock) reverts uv.lock when the only diff is timestamp noise.
 exclude-newer = "1 week"
 # repomatic is pinned to git main.
-exclude-newer-package = { "repomatic" = "0 day" }
+exclude-newer-package = { "repomatic" = "0 day",  pytest = "0 day"}
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,11 +3,12 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-07T06:32:03.427509Z"
+exclude-newer = "2026-04-07T11:21:06.168531078Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-repomatic = { timestamp = "2026-04-14T06:32:03.428232Z", span = "PT0S" }
+pytest = { timestamp = "2026-04-14T11:21:06.167439342Z", span = "PT0S" }
+repomatic = { timestamp = "2026-04-14T11:21:06.168536738Z", span = "PT0S" }
 
 [[package]]
 name = "aiofiles"
@@ -1322,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1333,9 +1334,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Upgrades packages with known security vulnerabilities detected by [`uv audit`](https://docs.astral.sh/uv/reference/cli/#uv-audit) against the [Python Packaging Advisory Database](https://github.com/pypa/advisory-database). Uses [`--exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) to bypass the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown for security fixes. See the [`fix-vulnerable-deps` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Vulnerabilities

| Package | Advisory | Current | Fixed |
| :-- | :-- | :-- | :-- |
| [pytest](https://pypi.org/project/pytest/) | [GHSA-6w46-j5rx-g56g](https://nvd.nist.gov/vuln/detail/CVE-2025-71176): pytest has vulnerable tmpdir handling | `9.0.2` | `9.0.3` |

### Updated packages

| Package | Change | Released |
| :-- | :-- | :-- |
| [pytest](https://pypi.org/project/pytest/) | `9.0.2` → `9.0.3` | 2026-04-07 |

### Release notes

<details>
<summary><code>pytest</code></summary>

#### [`9.0.3`](https://github.com/pytest-dev/pytest/releases/tag/9.0.3)

# pytest 9.0.3 (2026-04-07)

## Bug fixes

- [\#​12444](https://redirect.github.com/pytest-dev/pytest/issues/12444): Fixed `pytest.approx` which now correctly takes into account `~collections.abc.Mapping` keys order to compare them.

- [\#​13634](https://redirect.github.com/pytest-dev/pytest/issues/13634): Blocking a `conftest.py` file using the `-p no:` option is now explicitly disallowed.

  Previously this resulted in an internal assertion failure during plugin loading.

  Pytest now raises a clear `UsageError` explaining that conftest files are not plugins and cannot be disabled via `-p`.

- [\#​13734](https://redirect.github.com/pytest-dev/pytest/issues/13734): Fixed crash when a test raises an exceptiongroup with `__tracebackhide__ = True`.

- [\#​14195](https://redirect.github.com/pytest-dev/pytest/issues/14195): Fixed an issue where non-string messages passed to <span class="title-ref">unittest.TestCase.subTest()</span> were not printed.

- [\#​14343](https://redirect.github.com/pytest-dev/pytest/issues/14343): Fixed use of insecure temporary directory (CVE-2025-71176).

## Improved documentation

- [\#​13388](https://redirect.github.com/pytest-dev/pytest/issues/13388): Clarified documentation for `-p` vs `PYTEST_PLUGINS` plugin loading and fixed an incorrect `-p` example.
- [\#​13731](https://redirect.github.com/pytest-dev/pytest/issues/13731): Clarified that capture fixtures (e.g. `capsys` and `capfd`) take precedence over the `-s` / `--capture=no` command-line options in `Accessing captured output from a test function <accessing-captured-output>`.
- [\#​14088](https://redirect.github.com/pytest-dev/pytest/issues/14088): Clarified that the default `pytest_collection` hook sets `session.items` before it calls `pytest_collection_finish`, not after.
- [\#​14255](https://redirect.github.com/pytest-dev/pytest/issues/14255): TOML integer log levels must be quoted: Updating reference documentation.

## Contributor-facing changes

... [Full release notes](https://github.com/pytest-dev/pytest/releases/tag/9.0.3)

</details>


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`00539eeb`](https://github.com/kdeldycke/repomatic/commit/00539eeb92bd9e5383fed66c5d2271dd1171f1d0) |
| **Job** | [`fix-vulnerable-deps`](https://github.com/kdeldycke/repomatic/blob/00539eeb92bd9e5383fed66c5d2271dd1171f1d0/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/00539eeb92bd9e5383fed66c5d2271dd1171f1d0/.github/workflows/autofix.yaml) |
| **Run** | [#4347.1](https://github.com/kdeldycke/repomatic/actions/runs/24395979991) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0.dev0`