### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ typing = [ "types-boltons>=25.0.0.20250822", "types-pyyaml>=6.0.12.9" ]
 # (sync-uv-lock) reverts uv.lock when the only diff is timestamp noise.
 exclude-newer = "1 week"
 # repomatic is pinned to git main.
-exclude-newer-package = { "repomatic" = "0 day",  pytest = "0 day"}
+exclude-newer-package = { repomatic = "0 day" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,11 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-07T11:21:06.168531078Z"
+exclude-newer = "2026-04-08T04:44:18.098798337Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-pytest = { timestamp = "2026-04-14T11:21:06.167439342Z", span = "PT0S" }
-repomatic = { timestamp = "2026-04-14T11:21:06.168536738Z", span = "PT0S" }
+repomatic = { timestamp = "2026-04-15T04:44:18.098804809Z", span = "PT0S" }
 
 [[package]]
 name = "aiofiles"
@@ -1696,29 +1695,29 @@ wheels = [
 
 [[package]]
 name = "types-boltons"
-version = "25.0.0.20260402"
+version = "25.0.0.20260408"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/42/148b213d45c5f8ded83186c9e1cbc45cb0574e7690dd9d31abddff491944/types_boltons-25.0.0.20260402.tar.gz", hash = "sha256:d47111338d9fe6656a033b3a315c47ca961610564a3400629c232a1008b6402b", size = 21719, upload-time = "2026-04-02T04:18:56.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/22/daf1f2431453946a549a67d3f90851d046b19bca6e338f66282f7240c3f8/types_boltons-25.0.0.20260408.tar.gz", hash = "sha256:7b5e7b3083ce4352981bb31174a00b4ee7e0ead67491e697c528d2c751be30d8", size = 21759, upload-time = "2026-04-08T04:33:14.97Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/02/93c4f66067845a44bf8f9f927261fc5dc467f5401b8140ba0a29707c13b5/types_boltons-25.0.0.20260402-py3-none-any.whl", hash = "sha256:6bd69d8ceb53c7ab35482609471444a979a9ca4dea27853c68b624d72fa90d5a", size = 28277, upload-time = "2026-04-02T04:18:55.938Z" },
+    { url = "https://files.pythonhosted.org/packages/49/53/d3cf4241c28fc26da978fcee5664e07557f041d4d75e06889aa50b6cdb59/types_boltons-25.0.0.20260408-py3-none-any.whl", hash = "sha256:278663be699cd3482c88f1352a2acbfcd3a93d83d95ff17f77fa2f68f50c3904", size = 28276, upload-time = "2026-04-08T04:33:13.861Z" },
 ]
 
 [[package]]
 name = "types-pytz"
-version = "2026.1.1.20260402"
+version = "2026.1.1.20260408"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/ff/52b895d4cb5f51f4ae50de8ca6a0b4098a71fa174b63f14d80ba86fa0692/types_pytz-2026.1.1.20260402.tar.gz", hash = "sha256:79209aa51dc003a4a6a764234d92b14e5c09a1b7f24e0f00c493929fd33618e8", size = 10726, upload-time = "2026-04-02T04:17:52.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/b7/33f5a4f29b1f285b99ff79a607751a7996194cbb98705e331dab7a2daa28/types_pytz-2026.1.1.20260408.tar.gz", hash = "sha256:89b6a34b9198ea2a4b98a9d15cbca987053f52a105fd44f7ce3789cae4349408", size = 10788, upload-time = "2026-04-08T04:28:14.54Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/ce/93d4fc3ba66be6cd50f3f22bbdb6fd953a02689398ea2c4a733e023c9227/types_pytz-2026.1.1.20260402-py3-none-any.whl", hash = "sha256:0d9a60ed1c6ad4fce7c6395b5bd2d9827db41d4b83de7c0322cf85869c2bfda3", size = 10122, upload-time = "2026-04-02T04:17:51.729Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/90/12c059e6bb330a22d9cc97daf027ac7fb7f50fbf518e4d88185b4d39120e/types_pytz-2026.1.1.20260408-py3-none-any.whl", hash = "sha256:c7e4dec76221fb7d0c97b91ad8561d689bebe39b6bcb7b728387e7ffd8cde788", size = 10124, upload-time = "2026-04-08T04:28:13.353Z" },
 ]
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20250915"
+version = "6.0.12.20260408"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-08`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [types-boltons](https://pypi.org/project/types-boltons/) | [`25.0.0.20260402` → `25.0.0.20260408`](https://github.com/python/typeshed/compare/v25.0.0.20260402...v25.0.0.20260408) | 2026-04-08 |
| [types-pytz](https://pypi.org/project/types-pytz/) | [`2026.1.1.20260402` → `2026.1.1.20260408`](https://github.com/python/typeshed/compare/v2026.1.1.20260402...v2026.1.1.20260408) | 2026-04-08 |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | [`6.0.12.20250915` → `6.0.12.20260408`](https://github.com/python/typeshed/compare/v6.0.12.20250915...v6.0.12.20260408) | 2026-04-08 |

### Release notes

<details>
<summary><code>types-boltons</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/boltons.md)

</details>

<details>
<summary><code>types-pytz</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/pytz.md)

</details>

<details>
<summary><code>types-pyyaml</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/PyYAML.md)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`edecc165`](https://github.com/kdeldycke/repomatic/commit/edecc165c0d7cd23edd4854dfe1d1932ba00f0ea) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/edecc165c0d7cd23edd4854dfe1d1932ba00f0ea/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/edecc165c0d7cd23edd4854dfe1d1932ba00f0ea/.github/workflows/autofix.yaml) |
| **Run** | [#4360.1](https://github.com/kdeldycke/repomatic/actions/runs/24436830222) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0.dev0`