### PR TITLE
Format Markdown

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -254,13 +254,13 @@ workflow.source-paths = ["extra_platforms"]
 
 Some tools have long-standing requests to read configuration from `pyproject.toml` but haven't shipped native support yet. `repomatic run` bridges the gap: write your config in `[tool.<name>]` and repomatic translates it to the tool's native format at invocation time.
 
-| Tool                                              | `[tool.X]` section  | Translated to |
-| :------------------------------------------------ | :------------------ | :------------ |
-| [biome](https://biomejs.dev)                      | `[tool.biome]`      | JSON          |
-| [gitleaks](https://github.com/gitleaks/gitleaks)  | `[tool.gitleaks]`   | TOML          |
-| [lychee](https://lychee.cli.rs)                   | `[tool.lychee]`     | TOML          |
-| [yamllint](https://yamllint.readthedocs.io)       | `[tool.yamllint]`   | YAML          |
-| [zizmor](https://docs.zizmor.sh)                  | `[tool.zizmor]`     | YAML          |
+| Tool                                             | `[tool.X]` section | Translated to |
+| :----------------------------------------------- | :----------------- | :------------ |
+| [biome](https://biomejs.dev)                     | `[tool.biome]`     | JSON          |
+| [gitleaks](https://github.com/gitleaks/gitleaks) | `[tool.gitleaks]`  | TOML          |
+| [lychee](https://lychee.cli.rs)                  | `[tool.lychee]`    | TOML          |
+| [yamllint](https://yamllint.readthedocs.io)      | `[tool.yamllint]`  | YAML          |
+| [zizmor](https://docs.zizmor.sh)                 | `[tool.zizmor]`    | YAML          |
 
 ```toml
 # pyproject.toml


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e4e29c8f`](https://github.com/kdeldycke/repomatic/commit/e4e29c8f05711ab7e8922e06298366d76ac5d49a) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/repomatic/blob/e4e29c8f05711ab7e8922e06298366d76ac5d49a/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/e4e29c8f05711ab7e8922e06298366d76ac5d49a/.github/workflows/autofix.yaml) |
| **Run** | [#4362.1](https://github.com/kdeldycke/repomatic/actions/runs/24437738301) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0.dev0`