### PR TITLE
Format Python

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,22 +8,16 @@ project_path = Path(__file__).parent.parent.resolve()
 
 # Fetch general information about the project from pyproject.toml.
 toml_path = project_path / "pyproject.toml"
-toml_config = tomllib.loads(
-    toml_path.read_text(encoding="utf-8")
-)
+toml_config = tomllib.loads(toml_path.read_text(encoding="utf-8"))
 
 # Redistribute pyproject.toml config to Sphinx.
 project_id = toml_config["project"]["name"]
 version = release = toml_config["project"]["version"]
 url = toml_config["project"]["urls"]["Homepage"]
-author = ", ".join(
-    a["name"] for a in toml_config["project"]["authors"]
-)
+author = ", ".join(a["name"] for a in toml_config["project"]["authors"])
 
 # Title-case each word of the project ID.
-project = " ".join(
-    word.title() for word in project_id.split("-")
-)
+project = " ".join(word.title() for word in project_id.split("-"))
 
 # Addons.
 extensions = [
@@ -107,10 +101,7 @@ html_title = project
 html_theme_options = {
     "sidebar_hide_name": True,
     # Activates edit links.
-    "source_repository": (
-        "https://github.com/"
-        f"{issues_github_path}"
-    ),
+    "source_repository": (f"https://github.com/{issues_github_path}"),
     "source_branch": "main",
     "source_directory": "docs/",
     "announcement": (

--- a/repomatic/checksums.py
+++ b/repomatic/checksums.py
@@ -113,7 +113,9 @@ def update_checksums(file_path: Path) -> list[tuple[str, str, str]]:
 
     progress = (
         click.progressbar(
-            pairs, label="Verifying checksums", file=sys.stderr,
+            pairs,
+            label="Verifying checksums",
+            file=sys.stderr,
         )
         if sys.stderr.isatty()
         else nullcontext(pairs)
@@ -125,7 +127,8 @@ def update_checksums(file_path: Path) -> list[tuple[str, str, str]]:
 
             if old_hash != new_hash:
                 lines[hash_line_idx] = lines[hash_line_idx].replace(
-                    old_hash, new_hash,
+                    old_hash,
+                    new_hash,
                 )
                 updated.append((url, old_hash, new_hash))
                 logging.info(f"Updated checksum: {old_hash} -> {new_hash}")
@@ -154,8 +157,7 @@ def update_registry_checksums(registry_path: Path) -> list[tuple[str, str, str]]
 
     # Flatten all binary platform entries for progress tracking.
     entries = [
-        (spec, pk, tmpl.format(version=spec.version),
-         spec.binary.checksums[pk])
+        (spec, pk, tmpl.format(version=spec.version), spec.binary.checksums[pk])
         for spec in TOOL_REGISTRY.values()
         if spec.binary is not None
         for pk, tmpl in spec.binary.urls.items()
@@ -163,7 +165,9 @@ def update_registry_checksums(registry_path: Path) -> list[tuple[str, str, str]]
 
     progress = (
         click.progressbar(
-            entries, label="Verifying checksums", file=sys.stderr,
+            entries,
+            label="Verifying checksums",
+            file=sys.stderr,
         )
         if sys.stderr.isatty()
         else nullcontext(entries)
@@ -171,17 +175,14 @@ def update_registry_checksums(registry_path: Path) -> list[tuple[str, str, str]]
     with progress as items:
         for spec, platform_key, url, old_hash in items:
             logging.info(
-                f"Verifying registry checksum for"
-                f" {spec.name} ({platform_key})"
+                f"Verifying registry checksum for {spec.name} ({platform_key})"
             )
             new_hash = _download_sha256(url)
 
             if old_hash != new_hash:
                 content = content.replace(old_hash, new_hash)
                 updated.append((url, old_hash, new_hash))
-                logging.info(
-                    f"Updated checksum: {old_hash} -> {new_hash}"
-                )
+                logging.info(f"Updated checksum: {old_hash} -> {new_hash}")
             else:
                 logging.info("Checksum unchanged.")
 

--- a/repomatic/cli.py
+++ b/repomatic/cli.py
@@ -2267,7 +2267,11 @@ def setup_guide(
     fork_pr_gate = fork_pr_ok is not False
     pages_gate = bool(pages_ok) if md.is_sphinx else pages_ok is not False
     needs_issue = not (
-        token_ok and dependabot_ok and branch_ok and vt_ok and fork_pr_gate
+        token_ok
+        and dependabot_ok
+        and branch_ok
+        and vt_ok
+        and fork_pr_gate
         and pages_gate
     )
 
@@ -3485,9 +3489,7 @@ def scan_virustotal(
                 if updated:
                     echo(f"Updated release body for {tag}.")
                 else:
-                    echo(
-                        f"Release body for {tag} already has VirusTotal links."
-                    )
+                    echo(f"Release body for {tag} already has VirusTotal links.")
             elif results and update_release and not repo:
                 echo("No --repo specified, skipping release body update.")
 
@@ -3510,18 +3512,14 @@ def scan_virustotal(
             body = json.loads(raw).get("body", "")
             results = _extract_results_from_body(body)
             if not results:
-                echo(
-                    f"No VirusTotal section found in {tag} release body."
-                )
+                echo(f"No VirusTotal section found in {tag} release body.")
                 return
 
         echo(
             f"Polling VirusTotal for {len(results)} file(s)"
             f" (timeout {poll_timeout}s)..."
         )
-        enriched = poll_detection_stats(
-            api_key, results, rate_limit, poll_timeout
-        )
+        enriched = poll_detection_stats(api_key, results, rate_limit, poll_timeout)
 
         for r in enriched:
             stats = str(r.detection_stats) if r.detection_stats else "pending"

--- a/repomatic/github/gh.py
+++ b/repomatic/github/gh.py
@@ -73,11 +73,7 @@ def run_gh_command(args: list[str]) -> str:
         # fall back to GITHUB_TOKEN if available and different.
         fallback = os.environ.get("GITHUB_TOKEN")
         primary = pat or os.environ.get("GH_TOKEN")
-        if (
-            "Bad credentials" in stderr
-            and fallback
-            and fallback != primary
-        ):
+        if "Bad credentials" in stderr and fallback and fallback != primary:
             logging.warning(
                 "Primary token returned 401 Bad Credentials, "
                 "retrying with GITHUB_TOKEN.",

--- a/repomatic/init_project.py
+++ b/repomatic/init_project.py
@@ -643,8 +643,7 @@ def run_init(
                 if (
                     not scope_bypassed
                     and not is_source
-                    and entry.file_id
-                    not in include_files.get(reg_comp.name, set())
+                    and entry.file_id not in include_files.get(reg_comp.name, set())
                 ):
                     excluded_files.setdefault(reg_comp.name, set()).add(entry.file_id)
             if not is_source and not entry.is_enabled(config):

--- a/repomatic/metadata.py
+++ b/repomatic/metadata.py
@@ -1597,8 +1597,7 @@ class Metadata:
                 selected.append(cli_id)
             else:
                 logging.warning(
-                    f"Unrecognized nuitka entry point {cli_id!r};"
-                    f" valid: {all_cli_ids}"
+                    f"Unrecognized nuitka entry point {cli_id!r}; valid: {all_cli_ids}"
                 )
         return selected or all_cli_ids[:1]
 
@@ -2334,7 +2333,8 @@ class Metadata:
         # and subcommand config fields (read directly by test-plan and deps-graph).
         for f in fields(Config):
             if (
-                f.name not in (
+                f.name
+                not in (
                     "nuitka_entry_points",
                     "nuitka_extra_args",
                     "nuitka_unstable_targets",

--- a/repomatic/tool_runner.py
+++ b/repomatic/tool_runner.py
@@ -276,10 +276,7 @@ class BinarySpec:
         available = ", ".join(
             f"{k[0].name} {k[1].name}" for k in sorted(self.urls, key=str)
         )
-        msg = (
-            f"No binary for {plat.name} {arch.name}. "
-            f"Available: {available}."
-        )
+        msg = f"No binary for {plat.name} {arch.name}. Available: {available}."
         raise RuntimeError(msg)
 
     def get_archive_format(self, key: PlatformKey) -> ArchiveFormat:
@@ -308,10 +305,12 @@ class BinarySpec:
             if map_key == key_plat:
                 return fmt
             if isinstance(map_key, Group) and (
-                isinstance(key_plat, Platform) and key_plat in map_key
-                or isinstance(key_plat, Group) and (key_plat & map_key)
+                isinstance(key_plat, Platform)
+                and key_plat in map_key
+                or isinstance(key_plat, Group)
+                and (key_plat & map_key)
             ):
-                    group_hits.append((map_key, fmt))
+                group_hits.append((map_key, fmt))
 
         if group_hits:
             # Most-specific group: fewest members.
@@ -519,22 +518,61 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         default_flags=("-color",),
         binary=BinarySpec(
             urls={
-                (LINUX, AARCH64): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_linux_arm64.tar.gz",
-                (LINUX, X86_64): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_linux_amd64.tar.gz",
-                (MACOS, AARCH64): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_darwin_arm64.tar.gz",
-                (MACOS, X86_64): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_darwin_amd64.tar.gz",
-                (WINDOWS, AARCH64): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_windows_arm64.zip",
-                (WINDOWS, X86_64): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_windows_amd64.zip",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_linux_arm64.tar.gz",
+                (
+                    LINUX,
+                    X86_64,
+                ): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_linux_amd64.tar.gz",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_darwin_arm64.tar.gz",
+                (
+                    MACOS,
+                    X86_64,
+                ): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_darwin_amd64.tar.gz",
+                (
+                    WINDOWS,
+                    AARCH64,
+                ): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_windows_arm64.zip",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "https://github.com/rhysd/actionlint/releases/download/v{version}/actionlint_{version}_windows_amd64.zip",
             },
             checksums={
-                (LINUX, AARCH64): "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6",
-                (LINUX, X86_64): "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
-                (MACOS, AARCH64): "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f",
-                (MACOS, X86_64): "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644",
-                (WINDOWS, AARCH64): "cadcf7ea4efe3a68728893813643cebe1185e5b1d4be5b96245f65c9a4d5ea41",
-                (WINDOWS, X86_64): "6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f6e9",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6",
+                (
+                    LINUX,
+                    X86_64,
+                ): "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f",
+                (
+                    MACOS,
+                    X86_64,
+                ): "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644",
+                (
+                    WINDOWS,
+                    AARCH64,
+                ): "cadcf7ea4efe3a68728893813643cebe1185e5b1d4be5b96245f65c9a4d5ea41",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f6e9",
             },
-            archive_format={ALL_PLATFORMS: ArchiveFormat.TAR_GZ, WINDOWS: ArchiveFormat.ZIP},
+            archive_format={
+                ALL_PLATFORMS: ArchiveFormat.TAR_GZ,
+                WINDOWS: ArchiveFormat.ZIP,
+            },
         ),
     ),
     # autopep8 configuration reference:
@@ -568,20 +606,56 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         native_format=NativeFormat.JSON,
         binary=BinarySpec(
             urls={
-                (LINUX, AARCH64): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-linux-arm64",
-                (LINUX, X86_64): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-linux-x64",
-                (MACOS, AARCH64): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-darwin-arm64",
-                (MACOS, X86_64): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-darwin-x64",
-                (WINDOWS, AARCH64): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-win32-arm64.exe",
-                (WINDOWS, X86_64): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-win32-x64.exe",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-linux-arm64",
+                (
+                    LINUX,
+                    X86_64,
+                ): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-linux-x64",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-darwin-arm64",
+                (
+                    MACOS,
+                    X86_64,
+                ): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-darwin-x64",
+                (
+                    WINDOWS,
+                    AARCH64,
+                ): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-win32-arm64.exe",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40{version}/biome-win32-x64.exe",
             },
             checksums={
-                (LINUX, AARCH64): "98a109d54bfea7df1e82b73aa7d37fc2caa880d12105eb2495efe0d653955518",
-                (LINUX, X86_64): "a31815f19b0b90fa043eb23fbf769ed931fbcde6d98bb89894ea8be1387d8394",
-                (MACOS, AARCH64): "b50a1a5adca140554f44f6c89edcf6383b0b2e3baf9dcd08d597d1fd59f92544",
-                (MACOS, X86_64): "7f4d800ddc37c84a0a09aac1cd1ec77d1bbbdd5f97727f36f2062f6b639714e9",
-                (WINDOWS, AARCH64): "12750283a136a1535bcd87e76c67d855d6452274144464afe1c4e7184c1931c3",
-                (WINDOWS, X86_64): "8d382e6a5cd88f381eb7c2825bcce4fec0660fe366e93f95c8e6e2415fe16d21",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "98a109d54bfea7df1e82b73aa7d37fc2caa880d12105eb2495efe0d653955518",
+                (
+                    LINUX,
+                    X86_64,
+                ): "a31815f19b0b90fa043eb23fbf769ed931fbcde6d98bb89894ea8be1387d8394",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "b50a1a5adca140554f44f6c89edcf6383b0b2e3baf9dcd08d597d1fd59f92544",
+                (
+                    MACOS,
+                    X86_64,
+                ): "7f4d800ddc37c84a0a09aac1cd1ec77d1bbbdd5f97727f36f2062f6b639714e9",
+                (
+                    WINDOWS,
+                    AARCH64,
+                ): "12750283a136a1535bcd87e76c67d855d6452274144464afe1c4e7184c1931c3",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "8d382e6a5cd88f381eb7c2825bcce4fec0660fe366e93f95c8e6e2415fe16d21",
             },
             archive_format=ArchiveFormat.RAW,
         ),
@@ -612,22 +686,61 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         native_format=NativeFormat.TOML,
         binary=BinarySpec(
             urls={
-                (LINUX, AARCH64): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_linux_arm64.tar.gz",
-                (LINUX, X86_64): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_linux_x64.tar.gz",
-                (MACOS, AARCH64): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_darwin_arm64.tar.gz",
-                (MACOS, X86_64): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_darwin_x64.tar.gz",
-                (WINDOWS, AARCH64): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_windows_arm64.zip",
-                (WINDOWS, X86_64): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_windows_x64.zip",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_linux_arm64.tar.gz",
+                (
+                    LINUX,
+                    X86_64,
+                ): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_linux_x64.tar.gz",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_darwin_arm64.tar.gz",
+                (
+                    MACOS,
+                    X86_64,
+                ): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_darwin_x64.tar.gz",
+                (
+                    WINDOWS,
+                    AARCH64,
+                ): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_windows_arm64.zip",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "https://github.com/gitleaks/gitleaks/releases/download/v{version}/gitleaks_{version}_windows_x64.zip",
             },
             checksums={
-                (LINUX, AARCH64): "e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080",
-                (LINUX, X86_64): "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb",
-                (MACOS, AARCH64): "b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5",
-                (MACOS, X86_64): "dfe101a4db2255fc85120ac7f3d25e4342c3c20cf749f2c20a18081af1952709",
-                (WINDOWS, AARCH64): "b95f5e4f5c425cedca7ee203d9afd29597e692c4924a12ed42f970537c72cc0f",
-                (WINDOWS, X86_64): "d29144deff3a68aa93ced33dddf84b7fdc26070add4aa0f4513094c8332afc4e",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080",
+                (
+                    LINUX,
+                    X86_64,
+                ): "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5",
+                (
+                    MACOS,
+                    X86_64,
+                ): "dfe101a4db2255fc85120ac7f3d25e4342c3c20cf749f2c20a18081af1952709",
+                (
+                    WINDOWS,
+                    AARCH64,
+                ): "b95f5e4f5c425cedca7ee203d9afd29597e692c4924a12ed42f970537c72cc0f",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "d29144deff3a68aa93ced33dddf84b7fdc26070add4aa0f4513094c8332afc4e",
             },
-            archive_format={ALL_PLATFORMS: ArchiveFormat.TAR_GZ, WINDOWS: ArchiveFormat.ZIP},
+            archive_format={
+                ALL_PLATFORMS: ArchiveFormat.TAR_GZ,
+                WINDOWS: ArchiveFormat.ZIP,
+            },
         ),
     ),
     # labelmaker configuration reference:
@@ -639,20 +752,53 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         version="0.6.4",
         binary=BinarySpec(
             urls={
-                (LINUX, AARCH64): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-aarch64-unknown-linux-gnu.tar.xz",
-                (LINUX, X86_64): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-x86_64-unknown-linux-gnu.tar.xz",
-                (MACOS, AARCH64): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-aarch64-apple-darwin.tar.xz",
-                (MACOS, X86_64): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-x86_64-apple-darwin.tar.xz",
-                (WINDOWS, X86_64): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-x86_64-pc-windows-msvc.zip",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-aarch64-unknown-linux-gnu.tar.xz",
+                (
+                    LINUX,
+                    X86_64,
+                ): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-x86_64-unknown-linux-gnu.tar.xz",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-aarch64-apple-darwin.tar.xz",
+                (
+                    MACOS,
+                    X86_64,
+                ): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-x86_64-apple-darwin.tar.xz",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "https://github.com/jwodder/labelmaker/releases/download/v{version}/labelmaker-x86_64-pc-windows-msvc.zip",
             },
             checksums={
-                (LINUX, AARCH64): "4685e142da55150904d16624fe1052161de5dba1a859cddef19ab41833c37728",
-                (LINUX, X86_64): "d76f8e64f9671884dac1758fe54a28a6680c5d9bf0ffd593a2c68ba558cc49a2",
-                (MACOS, AARCH64): "a52a4e102f0760ce1632da5fdaee2b0debe0e6ddea577b88a94a60172fe85751",
-                (MACOS, X86_64): "dc8374d6a9bec4ebf143fb42e3024aeffabe8585bb9bd6f134cfaf0693be7688",
-                (WINDOWS, X86_64): "939195930f9d5fd2b15a5cf43497019a52083e6c6713807d3379de49395c2e10",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "4685e142da55150904d16624fe1052161de5dba1a859cddef19ab41833c37728",
+                (
+                    LINUX,
+                    X86_64,
+                ): "d76f8e64f9671884dac1758fe54a28a6680c5d9bf0ffd593a2c68ba558cc49a2",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "a52a4e102f0760ce1632da5fdaee2b0debe0e6ddea577b88a94a60172fe85751",
+                (
+                    MACOS,
+                    X86_64,
+                ): "dc8374d6a9bec4ebf143fb42e3024aeffabe8585bb9bd6f134cfaf0693be7688",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "939195930f9d5fd2b15a5cf43497019a52083e6c6713807d3379de49395c2e10",
             },
-            archive_format={ALL_PLATFORMS: ArchiveFormat.TAR_XZ, WINDOWS: ArchiveFormat.ZIP},
+            archive_format={
+                ALL_PLATFORMS: ArchiveFormat.TAR_XZ,
+                WINDOWS: ArchiveFormat.ZIP,
+            },
             strip_components=1,
         ),
     ),
@@ -670,18 +816,45 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         native_format=NativeFormat.TOML,
         binary=BinarySpec(
             urls={
-                (LINUX, AARCH64): "https://github.com/lycheeverse/lychee/releases/download/lychee-v{version}/lychee-aarch64-unknown-linux-gnu.tar.gz",
-                (LINUX, X86_64): "https://github.com/lycheeverse/lychee/releases/download/lychee-v{version}/lychee-x86_64-unknown-linux-gnu.tar.gz",
-                (MACOS, AARCH64): "https://github.com/lycheeverse/lychee/releases/download/lychee-v{version}/lychee-arm64-macos.tar.gz",
-                (WINDOWS, X86_64): "https://github.com/lycheeverse/lychee/releases/download/lychee-v{version}/lychee-x86_64-windows.exe",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "https://github.com/lycheeverse/lychee/releases/download/lychee-v{version}/lychee-aarch64-unknown-linux-gnu.tar.gz",
+                (
+                    LINUX,
+                    X86_64,
+                ): "https://github.com/lycheeverse/lychee/releases/download/lychee-v{version}/lychee-x86_64-unknown-linux-gnu.tar.gz",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "https://github.com/lycheeverse/lychee/releases/download/lychee-v{version}/lychee-arm64-macos.tar.gz",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "https://github.com/lycheeverse/lychee/releases/download/lychee-v{version}/lychee-x86_64-windows.exe",
             },
             checksums={
-                (LINUX, AARCH64): "97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0",
-                (LINUX, X86_64): "1fcb6ccf10d04c22b8c5873c5b9cb7be32ee7423e12169d6f1a79a6f1962ef81",
-                (MACOS, AARCH64): "1953bb425486e1b887757201e54e8fdf866c9cada6c270d8f6ed21ffbed4145a",
-                (WINDOWS, X86_64): "0fda7ff0a60c0250939fc25361c2d4e6e7853c31c996733fdd5a1dd760bcb824",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0",
+                (
+                    LINUX,
+                    X86_64,
+                ): "1fcb6ccf10d04c22b8c5873c5b9cb7be32ee7423e12169d6f1a79a6f1962ef81",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "1953bb425486e1b887757201e54e8fdf866c9cada6c270d8f6ed21ffbed4145a",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "0fda7ff0a60c0250939fc25361c2d4e6e7853c31c996733fdd5a1dd760bcb824",
             },
-            archive_format={ALL_PLATFORMS: ArchiveFormat.TAR_GZ, WINDOWS: ArchiveFormat.RAW},
+            archive_format={
+                ALL_PLATFORMS: ArchiveFormat.TAR_GZ,
+                WINDOWS: ArchiveFormat.RAW,
+            },
         ),
     ),
     # mdformat configuration reference:
@@ -781,18 +954,48 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         default_flags=("--write",),
         binary=BinarySpec(
             urls={
-                (LINUX, AARCH64): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_linux_arm64",
-                (LINUX, X86_64): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_linux_amd64",
-                (MACOS, AARCH64): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_darwin_arm64",
-                (MACOS, X86_64): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_darwin_amd64",
-                (WINDOWS, X86_64): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_windows_amd64.exe",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_linux_arm64",
+                (
+                    LINUX,
+                    X86_64,
+                ): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_linux_amd64",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_darwin_arm64",
+                (
+                    MACOS,
+                    X86_64,
+                ): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_darwin_amd64",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "https://github.com/mvdan/sh/releases/download/v{version}/shfmt_v{version}_windows_amd64.exe",
             },
             checksums={
-                (LINUX, AARCH64): "32d92acaa5cd8abb29fc49dac123dc412442d5713967819d8af2c29f1b3857c7",
-                (LINUX, X86_64): "fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1",
-                (MACOS, AARCH64): "9680526be4a66ea1ffe988ed08af58e1400fe1e4f4aef5bd88b20bb9b3da33f8",
-                (MACOS, X86_64): "6feedafc72915794163114f512348e2437d080d0047ef8b8fa2ec63b575f12af",
-                (WINDOWS, X86_64): "60cd368533d0ad73fa86d93d5bbf95ef40587245ce684ed138c1b31557b5fe97",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "32d92acaa5cd8abb29fc49dac123dc412442d5713967819d8af2c29f1b3857c7",
+                (
+                    LINUX,
+                    X86_64,
+                ): "fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "9680526be4a66ea1ffe988ed08af58e1400fe1e4f4aef5bd88b20bb9b3da33f8",
+                (
+                    MACOS,
+                    X86_64,
+                ): "6feedafc72915794163114f512348e2437d080d0047ef8b8fa2ec63b575f12af",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "60cd368533d0ad73fa86d93d5bbf95ef40587245ce684ed138c1b31557b5fe97",
             },
             archive_format=ArchiveFormat.RAW,
         ),
@@ -810,20 +1013,53 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         default_flags=("--write-changes",),
         binary=BinarySpec(
             urls={
-                (LINUX, AARCH64): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-aarch64-unknown-linux-musl.tar.gz",
-                (LINUX, X86_64): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-x86_64-unknown-linux-musl.tar.gz",
-                (MACOS, AARCH64): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-aarch64-apple-darwin.tar.gz",
-                (MACOS, X86_64): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-x86_64-apple-darwin.tar.gz",
-                (WINDOWS, X86_64): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-x86_64-pc-windows-msvc.zip",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-aarch64-unknown-linux-musl.tar.gz",
+                (
+                    LINUX,
+                    X86_64,
+                ): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-x86_64-unknown-linux-musl.tar.gz",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-aarch64-apple-darwin.tar.gz",
+                (
+                    MACOS,
+                    X86_64,
+                ): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-x86_64-apple-darwin.tar.gz",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "https://github.com/crate-ci/typos/releases/download/v{version}/typos-v{version}-x86_64-pc-windows-msvc.zip",
             },
             checksums={
-                (LINUX, AARCH64): "132c20fc5e3c9ba540ec55a0a468dcb9c1504625a405df1c237b10dd4f2ec433",
-                (LINUX, X86_64): "1b788b7d764e2f20fe089487428a3944ed218d1fb6fcd8eac4230b5893a38779",
-                (MACOS, AARCH64): "ca82d593351dbac519a5c9fa832fc147b176d80100d00d08e855fcb46d43882d",
-                (MACOS, X86_64): "70e7cbfd9c0bac3b27d096171413a8fff989cc9f9227d3ef66694ed99fdc7b5c",
-                (WINDOWS, X86_64): "afd85c8f3c5c925ee7452389acdf70b048d8c6eae5e52a581e63a7d1b7655f17",
+                (
+                    LINUX,
+                    AARCH64,
+                ): "132c20fc5e3c9ba540ec55a0a468dcb9c1504625a405df1c237b10dd4f2ec433",
+                (
+                    LINUX,
+                    X86_64,
+                ): "1b788b7d764e2f20fe089487428a3944ed218d1fb6fcd8eac4230b5893a38779",
+                (
+                    MACOS,
+                    AARCH64,
+                ): "ca82d593351dbac519a5c9fa832fc147b176d80100d00d08e855fcb46d43882d",
+                (
+                    MACOS,
+                    X86_64,
+                ): "70e7cbfd9c0bac3b27d096171413a8fff989cc9f9227d3ef66694ed99fdc7b5c",
+                (
+                    WINDOWS,
+                    X86_64,
+                ): "afd85c8f3c5c925ee7452389acdf70b048d8c6eae5e52a581e63a7d1b7655f17",
             },
-            archive_format={ALL_PLATFORMS: ArchiveFormat.TAR_GZ, WINDOWS: ArchiveFormat.ZIP},
+            archive_format={
+                ALL_PLATFORMS: ArchiveFormat.TAR_GZ,
+                WINDOWS: ArchiveFormat.ZIP,
+            },
         ),
     ),
     # yamllint configuration reference:

--- a/repomatic/virustotal.py
+++ b/repomatic/virustotal.py
@@ -237,19 +237,15 @@ def poll_detection_stats(
                         pending.discard(sha256)
                         r = by_sha[sha256]
                         logging.info(
-                            f"Analysis complete for {r.filename}:"
-                            f" {stats[sha256]}"
+                            f"Analysis complete for {r.filename}: {stats[sha256]}"
                         )
                 except vt.APIError:
-                    logging.debug(
-                        f"File {sha256[:12]}... not yet indexed, will retry."
-                    )
+                    logging.debug(f"File {sha256[:12]}... not yet indexed, will retry.")
 
     if pending:
         filenames = [by_sha[s].filename for s in pending]
         logging.warning(
-            f"Polling timed out after {timeout}s."
-            f" Missing results for: {filenames}"
+            f"Polling timed out after {timeout}s. Missing results for: {filenames}"
         )
 
     return [
@@ -288,11 +284,13 @@ def _extract_results_from_body(body: str) -> list[ScanResult]:
         m = _VT_ROW_RE.search(line)
         if m:
             filename, sha256 = m.group(1), m.group(2)
-            results.append(ScanResult(
-                filename=filename,
-                sha256=sha256,
-                analysis_url=VIRUSTOTAL_GUI_URL.format(sha256=sha256),
-            ))
+            results.append(
+                ScanResult(
+                    filename=filename,
+                    sha256=sha256,
+                    analysis_url=VIRUSTOTAL_GUI_URL.format(sha256=sha256),
+                )
+            )
 
     return results
 

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -31,7 +31,9 @@ def _make_result(
     stdout: str = "",
     stderr: str = "",
 ) -> CompletedProcess[str]:
-    return CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr)
+    return CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
 
 
 # Minimal env: no token vars at all.  Tests that need specific vars add them.

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -1512,9 +1512,7 @@ def test_include_bypasses_scope_for_bundled_component(
     """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
-        '[project]\nname = "test"\n\n'
-        "[tool.repomatic]\n"
-        'include = ["codecov"]\n',
+        '[project]\nname = "test"\n\n[tool.repomatic]\ninclude = ["codecov"]\n',
         encoding="UTF-8",
     )
     monkeypatch.chdir(tmp_path)
@@ -1536,9 +1534,7 @@ def test_include_bypasses_scope_for_tool_config(
     """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
-        '[project]\nname = "test"\n\n'
-        "[tool.repomatic]\n"
-        'include = ["lychee"]\n',
+        '[project]\nname = "test"\n\n[tool.repomatic]\ninclude = ["lychee"]\n',
         encoding="UTF-8",
     )
     monkeypatch.chdir(tmp_path)

--- a/tests/test_renovate.py
+++ b/tests/test_renovate.py
@@ -600,9 +600,7 @@ def test_format_diff_table():
     table = format_diff_table(changes)
     assert "### Updated packages" in table
     assert "| Package | Change |" in table
-    assert (
-        "| [anyio](https://pypi.org/project/anyio/) | `4.12.0` → `4.12.1` |" in table
-    )
+    assert "| [anyio](https://pypi.org/project/anyio/) | `4.12.0` → `4.12.1` |" in table
     assert "| [new-pkg](https://pypi.org/project/new-pkg/) | (new) `2.0.0` |" in table
     assert (
         "| [old-pkg](https://pypi.org/project/old-pkg/) | `1.0.0` (removed) |" in table
@@ -744,8 +742,7 @@ def test_add_exclude_newer_packages_multiple(tmp_path):
     # All three entries sorted, pyproject-fmt-compatible formatting.
     assert (
         'exclude-newer-package = { click-extra = "0 day",'
-        ' pygments = "0 day", requests = "0 day" }'
-        in content
+        ' pygments = "0 day", requests = "0 day" }' in content
     )
 
 
@@ -1025,8 +1022,7 @@ def test_find_preceding_comments():
 def test_find_preceding_comments_none():
     """Return empty string when no comment precedes the key."""
     text = (
-        'exclude-newer = "1 week"\n'
-        'exclude-newer-package = { "requests" = "0 day" }\n'
+        'exclude-newer = "1 week"\nexclude-newer-package = { "requests" = "0 day" }\n'
     )
     assert _find_preceding_comments(text, "exclude-newer-package") == ""
 
@@ -1436,7 +1432,12 @@ def test_format_release_notes_changelog_fallback():
     notes = {
         "json5": (
             "https://github.com/dpranke/pyjson5",
-            [("", "[Changelog](https://github.com/dpranke/pyjson5/blob/master/README.md)")],
+            [
+                (
+                    "",
+                    "[Changelog](https://github.com/dpranke/pyjson5/blob/master/README.md)",
+                )
+            ],
         ),
     }
     result = format_release_notes(notes)

--- a/tests/test_tool_runner.py
+++ b/tests/test_tool_runner.py
@@ -196,9 +196,7 @@ def test_tool_spec_integrity(name, spec):
 
         # URLs must be HTTPS.
         for key, url in spec.binary.urls.items():
-            assert url.startswith("https://"), (
-                f"{name}/{key}: URL must use HTTPS"
-            )
+            assert url.startswith("https://"), f"{name}/{key}: URL must use HTTPS"
 
         # archive_format: when a dict, all values must be ArchiveFormat
         # and all keys must be valid specifiers.
@@ -525,12 +523,13 @@ def test_extract_binary_format_override(tmp_path):
     spec = BinarySpec(
         urls={},
         checksums={},
-        archive_format={ALL_PLATFORMS: ArchiveFormat.TAR_GZ, WINDOWS: ArchiveFormat.ZIP},
+        archive_format={
+            ALL_PLATFORMS: ArchiveFormat.TAR_GZ,
+            WINDOWS: ArchiveFormat.ZIP,
+        },
     )
     # _install_binary resolves the format and passes it explicitly.
-    result = _extract_binary(
-        archive, spec, tmp_path, "gitleaks", ArchiveFormat.ZIP
-    )
+    result = _extract_binary(archive, spec, tmp_path, "gitleaks", ArchiveFormat.ZIP)
 
     assert result == tmp_path / "gitleaks.exe"
     assert result.exists()
@@ -543,7 +542,10 @@ def test_get_archive_format_dict_resolution():
     spec = BinarySpec(
         urls={},
         checksums={},
-        archive_format={ALL_PLATFORMS: ArchiveFormat.TAR_GZ, WINDOWS: ArchiveFormat.ZIP},
+        archive_format={
+            ALL_PLATFORMS: ArchiveFormat.TAR_GZ,
+            WINDOWS: ArchiveFormat.ZIP,
+        },
     )
     assert spec.get_archive_format((LINUX, X86_64)) == ArchiveFormat.TAR_GZ
     assert spec.get_archive_format((MACOS, AARCH64)) == ArchiveFormat.TAR_GZ
@@ -651,7 +653,9 @@ def test_install_binary_cache_miss_stores(tmp_path, monkeypatch):
     # Sidecar must be written after cache store.
     sidecar = expected_cache.with_suffix(expected_cache.suffix + ".sha256")
     assert sidecar.is_file()
-    assert sidecar.read_text(encoding="UTF-8") == hashlib.sha256(fake_binary).hexdigest()
+    assert (
+        sidecar.read_text(encoding="UTF-8") == hashlib.sha256(fake_binary).hexdigest()
+    )
 
 
 def test_install_binary_no_cache_flag(tmp_path, monkeypatch):

--- a/tests/test_virustotal.py
+++ b/tests/test_virustotal.py
@@ -129,9 +129,7 @@ def test_format_virustotal_section(sample_results):
 
 def test_format_virustotal_section_with_download_links(sample_results):
     """Binary names link to GitHub release assets when repo and tag are provided."""
-    section = format_virustotal_section(
-        sample_results, repo="owner/repo", tag="v1.0.0"
-    )
+    section = format_virustotal_section(sample_results, repo="owner/repo", tag="v1.0.0")
     assert (
         "[`app-1.0.0-linux-x64.bin`]"
         "(https://github.com/owner/repo/releases/download/v1.0.0/"
@@ -327,7 +325,7 @@ def test_poll_detection_stats():
         patch("repomatic.virustotal.vt.Client", return_value=mock_client),
         patch("repomatic.virustotal.time.sleep"),
     ):
-            enriched = poll_detection_stats("key", results, timeout=60)
+        enriched = poll_detection_stats("key", results, timeout=60)
 
     assert len(enriched) == 1
     assert enriched[0].detection_stats is not None

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -516,7 +516,8 @@ DATA_DIR = REPO_ROOT / "repomatic" / "data"
 # they are repomatic-internal (patching files that only exist in this repo) and
 # must not be exported to downstream repositories.
 WORKFLOWS_WITHOUT_SYMLINKS = frozenset((
-    "update-checksums.yaml",  # Patches repomatic/tool_runner.py, which only exists here.
+    # Patches repomatic/tool_runner.py, which only exists here.
+    "update-checksums.yaml",
 ))
 
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`4ff33891`](https://github.com/kdeldycke/repomatic/commit/4ff3389181e2306cb1f86f40c89e9632017f95fa) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/4ff3389181e2306cb1f86f40c89e9632017f95fa/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/4ff3389181e2306cb1f86f40c89e9632017f95fa/.github/workflows/autofix.yaml) |
| **Run** | [#4377.1](https://github.com/kdeldycke/repomatic/actions/runs/24462753913) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.1.dev0`