### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -7,11 +7,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-10T10:48:21.249727938Z"
+exclude-newer = "2026-04-12T10:48:52.325876141Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-repomatic = { timestamp = "2026-04-17T10:48:21.249736Z", span = "PT0S" }
+repomatic = { timestamp = "2026-04-19T10:48:52.325882733Z", span = "PT0S" }
 
 [[package]]
 name = "accessible-pygments"
@@ -1823,15 +1823,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-12`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [rich](https://pypi.org/project/rich/) | [`14.3.3` → `15.0.0`](https://github.com/Textualize/rich/compare/v14.3.3...v15.0.0) | 2026-04-12 |

### Release notes

<details>
<summary><code>rich</code></summary>

#### [`v14.3.4`](https://github.com/Textualize/rich/releases/tag/v14.3.4)

No new features in this release, but there should be improved startup time for Rich apps, and potentially improved runtime if you have a lot of links.

## [14.3.4] - 2026-04-11

### Changed

- Improved import time with lazy loading https://redirect.github.com/Textualize/rich/pull/4070
- Changed link id generation to avoid random number generation at runtime https://redirect.github.com/Textualize/rich/pull/3845

#### [`v15.0.0`](https://github.com/Textualize/rich/releases/tag/v15.0.0)

A few fixes. The major version bump is to honor the passing of 3.8 support which reached its EOL in October 7, 2024

## [15.0.0] - 2026-04-12

### Changed

- Breaking change: Dropped support for Python3.8

### Fixed

- Fixed empty print ignoring the `end` parameter https://redirect.github.com/Textualize/rich/pull/4075
- Fixed `Text.from_ansi` removing newlines https://redirect.github.com/Textualize/rich/pull/4076
- Fixed `FileProxy.isatty` not proxying https://redirect.github.com/Textualize/rich/pull/4077
- Fixed inline code in Markdown tables cells https://redirect.github.com/Textualize/rich/pull/4079

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`301587b3`](https://github.com/kdeldycke/repomatic/commit/301587b3952576dccd51a82b038178cab398eea3) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/301587b3952576dccd51a82b038178cab398eea3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/301587b3952576dccd51a82b038178cab398eea3/.github/workflows/autofix.yaml) |
| **Run** | [#4393.1](https://github.com/kdeldycke/repomatic/actions/runs/24627106777) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0.dev0`