### PR TITLE
Format Python

### DIFF
--- a/docs/docs_update.py
+++ b/docs/docs_update.py
@@ -83,11 +83,13 @@ def config_deflist() -> str:
         bare = option.strip("`")
         slug = _option_slug(option)
         table_rows.append([f"[`{bare}`](#{slug})", ftype, default])
-    lines.append(render_table(
-        table_rows,
-        headers=["Option", "Type", "Default"],
-        table_format=TableFormat.GITHUB,
-    ))
+    lines.append(
+        render_table(
+            table_rows,
+            headers=["Option", "Type", "Default"],
+            table_format=TableFormat.GITHUB,
+        )
+    )
     lines.append("")
 
     # Per-option heading sections.
@@ -156,11 +158,13 @@ def cli_reference() -> str:
         label = " ".join(path)
         desc = (cmd.get_short_help_str() or "").rstrip(".")
         table_rows.append([f"[`repomatic {label}`](#{anchor})", desc])
-    lines.append(render_table(
-        table_rows,
-        headers=["Command", "Description"],
-        table_format=TableFormat.GITHUB,
-    ))
+    lines.append(
+        render_table(
+            table_rows,
+            headers=["Command", "Description"],
+            table_format=TableFormat.GITHUB,
+        )
+    )
     lines.append("")
 
     # Main help screen.
@@ -354,9 +358,7 @@ def _badge_table(
     where align is ``"left"``, ``"center"`` (default), or ``"right"``.
     """
     headers = ["Tool"] + [c[0] for c in columns]
-    colalign = tuple(
-        ["left"] + [c[2] if len(c) > 2 else "center" for c in columns]
-    )
+    colalign = tuple(["left"] + [c[2] if len(c) > 2 else "center" for c in columns])
 
     table_rows: list[list[str]] = []
     for key in sorted(registry):
@@ -371,12 +373,14 @@ def _badge_table(
             cells.append(fn(key, spec, repo))
         table_rows.append(cells)
 
-    lines.append(render_table(
-        table_rows,
-        headers=headers,
-        table_format=TableFormat.GITHUB,
-        colalign=colalign,
-    ))
+    lines.append(
+        render_table(
+            table_rows,
+            headers=headers,
+            table_format=TableFormat.GITHUB,
+            colalign=colalign,
+        )
+    )
     lines.append("")
 
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e783b547`](https://github.com/kdeldycke/repomatic/commit/e783b547ca55040b3df55ecb4b61dbda8347dbac) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/e783b547ca55040b3df55ecb4b61dbda8347dbac/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/e783b547ca55040b3df55ecb4b61dbda8347dbac/.github/workflows/autofix.yaml) |
| **Run** | [#4396.1](https://github.com/kdeldycke/repomatic/actions/runs/24628005727) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0.dev0`