### PR TITLE
Format Python

### DIFF
--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -77,10 +77,7 @@ def test_docs_cli_help_matches() -> None:
     cli_text = CLI_MD.read_text(encoding="UTF-8")
     assert _normalize_config_path(result.output.rstrip()) in _normalize_config_path(
         cli_text
-    ), (
-        "CLI help output in docs/cli.md is out of sync. "
-        "Re-run: repomatic update-docs"
-    )
+    ), "CLI help output in docs/cli.md is out of sync. Re-run: repomatic update-docs"
 
 
 def test_docs_config_table_matches() -> None:
@@ -152,9 +149,7 @@ def test_docs_tip_table_covers_registry() -> None:
     read ``[tool.*]`` sections.
     """
     tool_table = _parse_tool_runner_table()
-    documented = {
-        name for name, support in tool_table.items() if "Native" in support
-    }
+    documented = {name for name, support in tool_table.items() if "Native" in support}
 
     native_readers = {
         name for name, spec in TOOL_REGISTRY.items() if spec.reads_pyproject


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`fbf72f90`](https://github.com/kdeldycke/repomatic/commit/fbf72f902e3159056609ab26e7ac1237bc8592c4) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/fbf72f902e3159056609ab26e7ac1237bc8592c4/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/fbf72f902e3159056609ab26e7ac1237bc8592c4/.github/workflows/autofix.yaml) |
| **Run** | [#4400.1](https://github.com/kdeldycke/repomatic/actions/runs/24650178002) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0.dev0`