### PR TITLE
Format Python

### DIFF
--- a/repomatic/cli.py
+++ b/repomatic/cli.py
@@ -1906,8 +1906,8 @@ def convert_to_myst(directory: str | None) -> None:
     Safe to re-run: already-converted MyST syntax does not match the reST
     patterns, so the conversion is idempotent.
     """
-    from .myst_converter import convert_directory
     from .metadata import Metadata
+    from .myst_converter import convert_directory
 
     if directory:
         root = Path(directory)

--- a/repomatic/myst_converter.py
+++ b/repomatic/myst_converter.py
@@ -225,8 +225,7 @@ def convert_comment_blocks(text: str) -> str:
                 break
             # Strip the #: prefix (with optional trailing space).
             after = s[2:]
-            if after.startswith(" "):
-                after = after[1:]
+            after = after.removeprefix(" ")
             block_contents.append(after)
             i += 1
 
@@ -285,8 +284,9 @@ def convert_directory(directory: Path) -> list[Path]:
     :param directory: Directory to process recursively.
     :returns: List of files that were modified.
     """
-    changed: list[Path] = []
-    for filepath in sorted(directory.glob("**/*.py")):
-        if convert_file(filepath):
-            changed.append(filepath)
+    changed: list[Path] = [
+        filepath
+        for filepath in sorted(directory.glob("**/*.py"))
+        if convert_file(filepath)
+    ]
     return changed

--- a/repomatic/myst_docstrings.py
+++ b/repomatic/myst_docstrings.py
@@ -112,9 +112,7 @@ def _convert_fence(match: re.Match) -> str:
             # Preserve relative indentation within the body.
             stripped = line.lstrip()
             extra_spaces = len(line) - len(stripped) - len(indent)
-            converted_lines.append(
-                body_indent + " " * max(0, extra_spaces) + stripped
-            )
+            converted_lines.append(body_indent + " " * max(0, extra_spaces) + stripped)
         else:
             converted_lines.append("")
 

--- a/tests/test_myst_docstrings.py
+++ b/tests/test_myst_docstrings.py
@@ -262,8 +262,7 @@ def test_real_detection_function():
     assert ":data:`~extra_platforms.ANDROID`" in result
     assert ".. seealso::" in result
     assert (
-        "    `kivy/utils.py"
-        " <https://github.com/kivy/kivy/blob/master/kivy/utils.py>`_"
+        "    `kivy/utils.py <https://github.com/kivy/kivy/blob/master/kivy/utils.py>`_"
     ) in result
 
 
@@ -305,7 +304,6 @@ def test_real_caution_with_code_block():
     assert ":data:`True`" in result
     assert ".. caution::" in result
     assert (
-        "    ``platform.machine()`` returns different values"
-        " depending on the OS:"
+        "    ``platform.machine()`` returns different values depending on the OS:"
     ) in result
     assert "    - Linux: ``aarch64``" in result


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`ad436af6`](https://github.com/kdeldycke/repomatic/commit/ad436af62fb2be1578fcd5a2008ee2894a6cc351) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/ad436af62fb2be1578fcd5a2008ee2894a6cc351/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/ad436af62fb2be1578fcd5a2008ee2894a6cc351/.github/workflows/autofix.yaml) |
| **Run** | [#4410.1](https://github.com/kdeldycke/repomatic/actions/runs/24684119825) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0.dev0`