### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -7,11 +7,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-13T19:00:26.51716924Z"
+exclude-newer = "2026-04-13T21:28:09.060259447Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-repomatic = { timestamp = "2026-04-20T19:00:26.517175913Z", span = "PT0S" }
+repomatic = { timestamp = "2026-04-20T21:28:09.060267281Z", span = "PT0S" }
 
 [[package]]
 name = "accessible-pygments"
@@ -423,7 +423,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.10.1"
+version = "7.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -436,9 +436,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/2b/a9863024cc55ce065316efd3acfd4faff133d864e66dd1ed61ad367bc468/click_extra-7.10.1.tar.gz", hash = "sha256:dbee5339f27474a7bd1fc83b80c498e1cf7d1f48128598006aadeec83834c27f", size = 118640, upload-time = "2026-04-07T06:09:46.469Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/ad/19d0f515efe5acb3ef123633336dac0532d7c83c1dc91931633f57c988d4/click_extra-7.11.0.tar.gz", hash = "sha256:2d0e29bdde869ac906b59fc5b4fb30388a0b7fba7a136c0f6984c51f152d81ef", size = 126049, upload-time = "2026-04-13T21:00:34.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/70/39a4c1dbf27a53f5b65b6bb56fd17e3f3c0d3348646465ee204b22b28beb/click_extra-7.10.1-py3-none-any.whl", hash = "sha256:799440c29acab9937e2054ee27e515cc0cd1a27920fc7b1616fcec35d0d79234", size = 131440, upload-time = "2026-04-07T06:09:47.773Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3e/dea5985478609aa07dc86c33f35c500e6e6c608a045df5300899cd51a312/click_extra-7.11.0-py3-none-any.whl", hash = "sha256:beb68eb2d41f287fdd38269aa87b295027605edac17961ff8de60ce3d8746f8d", size = 138046, upload-time = "2026-04-13T21:00:33.516Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-13`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | [`7.10.1` → `7.11.0`](https://github.com/kdeldycke/click-extra/compare/v7.10.1...v7.11.0) | 2026-04-13 |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v7.11.0`](https://github.com/kdeldycke/click-extra/releases/tag/v7.11.0)

> [!NOTE]
> `7.11.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/7.11.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v7.11.0).

- Add `serialize_data()` and `print_data()` functions for serializing arbitrary nested Python data (not just tabular rows) to JSON, HJSON, TOML, YAML, and XML. Complements the existing `render_table()`/`print_table()` pair.
- Add `sort_key` parameter to `render_table()` and `print_table()` for pre-render row sorting.
- Catch `ImportError` from missing optional dependencies in `print_table()` and `print_data()`, producing a clean one-line error instead of a traceback. The `print_data()` `package` parameter lets downstream projects customize install instructions.
- Add `print_sorted_table()` and `SortByOption` for column-based table sorting. `SortByOption` generates a `--sort-by` CLI option from column definitions and auto-wires `ctx.print_table` to the sorted variant.
- Add auto-injected `help` subcommand to `ExtraGroup`. `mycli help` shows group help, `mycli help subcommand` shows that subcommand's help (with nested group resolution). `mycli help --search term` searches all subcommands for matching options or descriptions. Disable with `help_command=False`.
- Relax `ParamStructure._recurse_cmd` to skip subcommands whose name collides with a top-level parameter (e.g. the `help` subcommand vs Click's `--help` option) instead of raising.
- Expose `HelpKeywords` dataclass and `collect_keywords()` as public API for extending help screen highlighting. `collect_keywords()` (renamed from the private `_collect_keywords()`) can be overridden to customize keyword collection.
- Add `extra_keywords` and `excluded_keywords` parameters to `ExtraCommand` and `ExtraGroup`. `extra_keywords` injects additional strings for highlighting; `excluded_keywords` suppresses highlighting of specific strings. Both accept a `HelpKeywords` instance.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v7.11.0)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`cc5ff21a`](https://github.com/kdeldycke/repomatic/commit/cc5ff21a8ab19a97353d8c5246556fefcc3b4bcd) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/cc5ff21a8ab19a97353d8c5246556fefcc3b4bcd/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/cc5ff21a8ab19a97353d8c5246556fefcc3b4bcd/.github/workflows/autofix.yaml) |
| **Run** | [#4430.1](https://github.com/kdeldycke/repomatic/actions/runs/24691260208) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0.dev0`