### PR TITLE
Format Python

### DIFF
--- a/tests/test_myst_docstrings.py
+++ b/tests/test_myst_docstrings.py
@@ -800,16 +800,7 @@ def test_nested_same_type_fences_not_supported():
     fence, may not parse correctly because the regex matches the first closing
     fence it finds.
     """
-    myst = (
-        ":::{note}\n"
-        "Outer content.\n"
-        "\n"
-        ":::{warning}\n"
-        "Inner content.\n"
-        ":::\n"
-        "\n"
-        ":::"
-    )
+    myst = ":::{note}\nOuter content.\n\n:::{warning}\nInner content.\n:::\n\n:::"
     result = _convert(myst)
     # The outer note should be converted.
     assert ".. note::" in result
@@ -825,13 +816,7 @@ def test_directive_inside_field_list_not_supported():
     Block-level MyST content (admonitions, code blocks) inside them is
     converted by the regex but won't render correctly in Sphinx.
     """
-    myst = (
-        ":param path: The path.\n"
-        "\n"
-        "    :::{note}\n"
-        "    Extra info.\n"
-        "    :::\n"
-    )
+    myst = ":param path: The path.\n\n    :::{note}\n    Extra info.\n    :::\n"
     result = _convert(myst)
     # The directive syntax is converted (the regex does not know about context).
     assert ".. note::" in result


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`c597fdaa`](https://github.com/kdeldycke/repomatic/commit/c597fdaa070475dfbddd35c76050dcb26c236d08) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/c597fdaa070475dfbddd35c76050dcb26c236d08/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/c597fdaa070475dfbddd35c76050dcb26c236d08/.github/workflows/autofix.yaml) |
| **Run** | [#4435.1](https://github.com/kdeldycke/repomatic/actions/runs/24710245132) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.1.dev0`