### PR TITLE
Fix vulnerable dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ dependency-groups.docs = { requires-python = ">= 3.14" }
 # (sync-uv-lock) reverts uv.lock when the only diff is timestamp noise.
 exclude-newer = "1 week"
 # repomatic is pinned to git main.
-exclude-newer-package = { repomatic = "0 day" }
+exclude-newer-package = { gitpython = "0 day", repomatic = "0 day" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,11 +7,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-19T21:10:34.496333096Z"
+exclude-newer = "2026-04-19T22:58:44.099390378Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-repomatic = { timestamp = "2026-04-26T21:10:34.496340169Z", span = "PT0S" }
+gitpython = { timestamp = "2026-04-26T22:58:44.098054737Z", span = "PT0S" }
+repomatic = { timestamp = "2026-04-26T22:58:44.099397558Z", span = "PT0S" }
 
 [[package]]
 name = "accessible-pygments"
@@ -787,14 +788,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.47"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Upgrades packages with known security vulnerabilities detected by [`uv audit`](https://docs.astral.sh/uv/reference/cli/#uv-audit) against the [Python Packaging Advisory Database](https://github.com/pypa/advisory-database). Uses [`--exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) to bypass the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown for security fixes. See the [`fix-vulnerable-deps` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Vulnerabilities

| Package | Advisory | Current | Fixed | Sources |
| :-- | :-- | :-- | :-- | :-- |
| [GitPython](https://pypi.org/project/GitPython/) | [GHSA-rpm5-65cw-6hj4](https://github.com/advisories/GHSA-rpm5-65cw-6hj4): GitPython has Command Injection via Git options bypass | `3.1.46` | `3.1.47` | [`github-advisories`](https://github.com/advisories/GHSA-rpm5-65cw-6hj4) |
| [GitPython](https://pypi.org/project/GitPython/) | [GHSA-x2qx-6953-8485](https://github.com/advisories/GHSA-x2qx-6953-8485): GitPython: Unsafe option check validates multi_options before shlex.split transformation | `3.1.46` | `3.1.47` | [`github-advisories`](https://github.com/advisories/GHSA-x2qx-6953-8485) |

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-19`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [gitpython](https://pypi.org/project/gitpython/) | `3.1.46` → `3.1.47` | 2026-04-22 |

### Release notes

<details>
<summary><code>gitpython</code></summary>

#### [`3.1.47`](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.47)

## Advisories

* https://redirect.github.com/gitpython-developers/GitPython/security/advisories/GHSA-rpm5-65cw-6hj4
* https://redirect.github.com/gitpython-developers/GitPython/security/advisories/GHSA-x2qx-6953-8485

## What's Changed
* Prepare next release by @​Byron in https://redirect.github.com/gitpython-developers/GitPython/pull/2095
* Bump git/ext/gitdb from `335c0f6` to `4c63ee6` by @​dependabot[bot] in https://redirect.github.com/gitpython-developers/GitPython/pull/2096
* DOC: README Add urls and updated a relative url by @​Timour-Ilyas in https://redirect.github.com/gitpython-developers/GitPython/pull/2098
* Fix GitConfigParser ignoring multiple [include] path entries by @​daniel7an in https://redirect.github.com/gitpython-developers/GitPython/pull/2100
* Switch back from Alpine to Debian for WSL by @​EliahKagan in https://redirect.github.com/gitpython-developers/GitPython/pull/2108
* Bump git/ext/gitdb from `4c63ee6` to `5c1b303` by @​dependabot[bot] in https://redirect.github.com/gitpython-developers/GitPython/pull/2106
* Run `gc.collect()` twice in `test_rename` on Python 3.12 by @​EliahKagan in https://redirect.github.com/gitpython-developers/GitPython/pull/2109
* fix: guard AutoInterrupt terminate during interpreter shutdown by @​lweyrich1 in https://redirect.github.com/gitpython-developers/GitPython/pull/2105
* Improve CI infrastructure for pre-commit by @​EliahKagan in https://redirect.github.com/gitpython-developers/GitPython/pull/2110
* Bump the pre-commit group with 5 updates by @​dependabot[bot] in https://redirect.github.com/gitpython-developers/GitPython/pull/2111
* Upgrade Sphinx for 3.14 support; drop doc build support on 3.8; test 3.14 by @​EliahKagan in https://redirect.github.com/gitpython-developers/GitPython/pull/2112
* Fix `Repo.active_branch` resolution for reftable-backed repositories by @​Copilot in https://redirect.github.com/gitpython-developers/GitPython/pull/2114

... [Full release notes](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.47)

</details>


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`784a5500`](https://github.com/kdeldycke/repomatic/commit/784a5500bc85fc3b88c670188ef1c1fc4cfb2186) |
| **Job** | [`fix-vulnerable-deps`](https://github.com/kdeldycke/repomatic/blob/784a5500bc85fc3b88c670188ef1c1fc4cfb2186/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/784a5500bc85fc3b88c670188ef1c1fc4cfb2186/.github/workflows/autofix.yaml) |
| **Run** | [#4464.1](https://github.com/kdeldycke/repomatic/actions/runs/24968511033) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.15.0.dev0`