### PR TITLE
Format Python

### DIFF
--- a/repomatic/cli.py
+++ b/repomatic/cli.py
@@ -168,8 +168,8 @@ from .tool_runner import (
     run_tool,
 )
 from .uv import (
-    _format_upload_date,
     AdvisorySource,
+    _format_upload_date,
     build_comparison_urls,
     fetch_release_notes,
     fix_vulnerable_deps as _fix_vulnerable_deps,

--- a/repomatic/github/advisories.py
+++ b/repomatic/github/advisories.py
@@ -104,9 +104,8 @@ def fetch_dependabot_alerts(repo: str) -> list[VulnerablePackage]:
             current_version = ""  # filled in by the caller from parse_lock_versions
         ghsa_id = advisory.get("ghsa_id", "")
         summary = advisory.get("summary", "")
-        url = (
-            advisory.get("html_url")
-            or (f"https://github.com/advisories/{ghsa_id}" if ghsa_id else "")
+        url = advisory.get("html_url") or (
+            f"https://github.com/advisories/{ghsa_id}" if ghsa_id else ""
         )
         vulns.append(
             VulnerablePackage(
@@ -117,9 +116,7 @@ def fetch_dependabot_alerts(repo: str) -> list[VulnerablePackage]:
                 fixed_version=first_patched,
                 advisory_url=url,
                 sources={AdvisorySource.GITHUB_ADVISORIES},
-                source_urls=(
-                    {AdvisorySource.GITHUB_ADVISORIES: url} if url else {}
-                ),
+                source_urls=({AdvisorySource.GITHUB_ADVISORIES: url} if url else {}),
             )
         )
     logging.info(f"Fetched {len(vulns)} fixable Dependabot alert(s) for {repo}.")

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -233,9 +233,7 @@ def test_collect_respects_sources_filter(lock_with_raspberry):
         )
 
     audit.assert_not_called()
-    assert all(
-        v.sources == {AdvisorySource.GITHUB_ADVISORIES} for v in result
-    )
+    assert all(v.sources == {AdvisorySource.GITHUB_ADVISORIES} for v in result)
 
 
 def test_collect_backfills_current_version_across_case_difference(tmp_path):
@@ -309,8 +307,7 @@ def test_format_vulnerability_table_links_each_source_to_its_url():
     table = format_vulnerability_table(vulns)
     assert "[`uv-audit`](https://osv.dev/vulnerability/PYSEC)" in table
     assert (
-        "[`github-advisories`]"
-        "(https://github.com/advisories/GHSA-orchard-9999-yyyy)"
+        "[`github-advisories`](https://github.com/advisories/GHSA-orchard-9999-yyyy)"
     ) in table
 
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`784a5500`](https://github.com/kdeldycke/repomatic/commit/784a5500bc85fc3b88c670188ef1c1fc4cfb2186) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/784a5500bc85fc3b88c670188ef1c1fc4cfb2186/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/784a5500bc85fc3b88c670188ef1c1fc4cfb2186/.github/workflows/autofix.yaml) |
| **Run** | [#4464.1](https://github.com/kdeldycke/repomatic/actions/runs/24968511033) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.15.0.dev0`