### PR TITLE
Format Python

### DIFF
--- a/repomatic/github/workflow_sync.py
+++ b/repomatic/github/workflow_sync.py
@@ -1232,9 +1232,7 @@ def generate_workflows(
                 continue
 
             try:
-                canonical_header = generate_workflow_header(
-                    filename, paths_spec=spec
-                )
+                canonical_header = generate_workflow_header(filename, paths_spec=spec)
             except (ValueError, FileNotFoundError) as e:
                 logging.error(f"Failed to extract header for {filename}: {e}")
                 errors += 1

--- a/repomatic/init_project.py
+++ b/repomatic/init_project.py
@@ -837,9 +837,7 @@ def _init_workflows(
             continue
         rel = target.relative_to(output_dir).as_posix()
         try:
-            canonical_header = generate_workflow_header(
-                filename, paths_spec=paths_spec
-            )
+            canonical_header = generate_workflow_header(filename, paths_spec=paths_spec)
         except (ValueError, FileNotFoundError):
             logging.warning(f"Cannot extract header for {filename}. Skipping.")
             continue

--- a/tests/test_workflow_sync.py
+++ b/tests/test_workflow_sync.py
@@ -566,8 +566,7 @@ def test_extra_trigger(tmp_path: Path) -> None:
             for k, v in trigger_config.items():
                 if isinstance(v, list):
                     on_lines.append(f"    {k}:")
-                    for item in v:
-                        on_lines.append(f"      - {item}")
+                    on_lines.extend(f"      - {item}" for item in v)
                 else:
                     on_lines.append(f"    {k}: {v}")
     on_lines.append("  workflow_dispatch:")
@@ -1169,7 +1168,11 @@ def test_adapt_trigger_paths_none_drops_upstream_keeps_universal() -> None:
     """Drop upstream paths but keep universal entries when source_paths is None."""
     config = {
         "branches": ["main"],
-        "paths": [UPSTREAM_SOURCE_GLOB, "pyproject.toml", "repomatic/data/renovate.json5"],
+        "paths": [
+            UPSTREAM_SOURCE_GLOB,
+            "pyproject.toml",
+            "repomatic/data/renovate.json5",
+        ],
     }
     result = _adapt_trigger_paths(config, "tests.yaml", PathsSpec())
     assert result["branches"] == ["main"]
@@ -1492,7 +1495,7 @@ def test_resolve_source_paths_no_name_returns_none() -> None:
         ('"', ('"', "")),
         ("'", ("'", "")),
         ('""', ("", '"')),
-        ("\"mixed'\"", ("mixed'", '"')),
+        ('"mixed\'"', ("mixed'", '"')),
         ("path/with/slashes", ("path/with/slashes", "")),
     ],
 )
@@ -1614,7 +1617,7 @@ def test_header_ignore_applies_before_extras() -> None:
     assert "pyproject.toml" in header
     # Find one paths block: pyproject.toml appears once and is the last entry.
     block_start = header.index("    paths:")
-    block_end = header.index("\n", header.index("\n", block_start) + 1)
+    header.index("\n", header.index("\n", block_start) + 1)
     # Walk to the end of the contiguous block.
     lines = header[block_start:].splitlines()
     block_lines = [lines[0]]


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`79ac983e`](https://github.com/kdeldycke/repomatic/commit/79ac983e51a26cd51560543af9a8e65dcdbf6fa3) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/79ac983e51a26cd51560543af9a8e65dcdbf6fa3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/79ac983e51a26cd51560543af9a8e65dcdbf6fa3/.github/workflows/autofix.yaml) |
| **Run** | [#4481.1](https://github.com/kdeldycke/repomatic/actions/runs/25003894563) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0.dev0`