### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -630,11 +630,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "11.0.5"
+version = "11.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ab/757eb1e8b77757651dd0c69d18d118b22608be551dfc06e3f3962f6bb474/extra_platforms-11.0.5.tar.gz", hash = "sha256:89ae7971ba79193a256af16b44f3b9ab1c16dc4ba671f80e6110fa421679a82e", size = 68848, upload-time = "2026-04-03T09:46:30.122Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/7b/0049f8a7817ac4eb6ad1af72c7938fff3e2677d55468c87de792208e068c/extra_platforms-11.1.0.tar.gz", hash = "sha256:3045d722cab2b422a8fcbcba7f52026c33523cb147616d99fc50947f8e952375", size = 69265, upload-time = "2026-04-21T08:28:21.694Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/07/f1644d0288f5ce4ad8b6c888dd46bced2eae3480265f2253cefd7f694a68/extra_platforms-11.0.5-py3-none-any.whl", hash = "sha256:b081d5b1159af6462793517ad8073f85bd4c31aa398dfb8acb7f49ff54f8b7cc", size = 72395, upload-time = "2026-04-03T09:46:31.413Z" },
+    { url = "https://files.pythonhosted.org/packages/38/75/5985d4b10248cc03f5d0ef03026f3cc69a427baa77b6b07fe26a674bba1a/extra_platforms-11.1.0-py3-none-any.whl", hash = "sha256:5d4476774e5d639813060c239b40481a714f785515db66bcbb19a7b3881debc1", size = 72560, upload-time = "2026-04-21T08:28:20.216Z" },
 ]
 
 [[package]]
@@ -788,14 +788,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/c3/e4a9656f3cdb280f5dc65a68cc6fc46e79f897d27c1a36bbb4f0f47aaac5/gitpython-3.1.48.tar.gz", hash = "sha256:b7c49ff4a49946fce38ac84116efa311b15e7dad06dc3787fc9e206bf9ef75e1", size = 217288, upload-time = "2026-04-28T05:35:45.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/50/bb9703c364c00e7be67ccda03536f3d684766ce109d184c9d1f072d866ca/gitpython-3.1.48-py3-none-any.whl", hash = "sha256:737698b05889cca0f9aba7054d796620df2092c68926ee1470e5c7f5ac886680", size = 209800, upload-time = "2026-04-28T05:35:42.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-21`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`11.0.5` → `11.1.0`](https://github.com/kdeldycke/extra-platforms/compare/v11.0.5...v11.1.0) | 2026-04-21 |
| [gitpython](https://pypi.org/project/gitpython/) | [`3.1.47` → `3.1.48`](https://github.com/gitpython-developers/GitPython/compare/3.1.47...3.1.48) | 2026-04-28 |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v11.1.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v11.1.0)

> [!NOTE]
> `11.1.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/11.1.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v11.1.0).

- Add NixOS platform detection.
- Convert Python docstrings to MyST markdown; render them with the `repomatic.myst_docstrings` Sphinx extension.
- Expand CI test matrix to cover Ubuntu 22.04, Ubuntu 22.04 ARM, macOS 14, macOS 15, and Windows 2022.

**Full changelog**: [`v11.0.5...v11.1.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v11.0.5...v11.1.0)

</details>

<details>
<summary><code>gitpython</code></summary>

#### [`3.1.48`](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.48)

Fixes https://redirect.github.com/gitpython-developers/GitPython/pull/2134 

## What's Changed
* prevent out-of-repo access when manipulating references. by @​Byron in https://redirect.github.com/gitpython-developers/GitPython/pull/2134


**Full Changelog**: https://redirect.github.com/gitpython-developers/GitPython/compare/3.1.47...3.1.48

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`4b70580f`](https://github.com/kdeldycke/repomatic/commit/4b70580fb41ccb822af763fcfea7190fa823a9f0) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/4b70580fb41ccb822af763fcfea7190fa823a9f0/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/4b70580fb41ccb822af763fcfea7190fa823a9f0/.github/workflows/autofix.yaml) |
| **Run** | [#4495.1](https://github.com/kdeldycke/repomatic/actions/runs/25048076286) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0.dev0`