### PR TITLE
Format Python

### DIFF
--- a/docs/docs_update.py
+++ b/docs/docs_update.py
@@ -561,9 +561,7 @@ def _python_compat_groups() -> list[tuple[str, str, str, tuple[str, ...]]]:
         )
         if show.returncode != 0:
             continue
-        versions = tuple(
-            sorted(set(classifier_re.findall(show.stdout)), key=_sort_key)
-        )
+        versions = tuple(sorted(set(classifier_re.findall(show.stdout)), key=_sort_key))
         if not versions:
             continue
         if groups and groups[-1][3] == versions:
@@ -586,9 +584,7 @@ def python_compat_table() -> str:
     def _sort_key(version: str) -> tuple[int, ...]:
         return tuple(int(p) for p in version.split("."))
 
-    all_versions = sorted(
-        {v for _, _, _, vers in groups for v in vers}, key=_sort_key
-    )
+    all_versions = sorted({v for _, _, _, vers in groups for v in vers}, key=_sort_key)
 
     def _range_label(first: str, last: str) -> str:
         first_minor = ".".join(first.lstrip("v").split(".")[:2])

--- a/repomatic/config.py
+++ b/repomatic/config.py
@@ -739,9 +739,7 @@ def _extract_field_docstrings(
                     docstrings[current_field] = text
                 else:
                     # Collapse the first paragraph onto a single line.
-                    docstrings[current_field] = " ".join(
-                        text.split("\n\n")[0].split()
-                    )
+                    docstrings[current_field] = " ".join(text.split("\n\n")[0].split())
                 current_field = None
         else:
             current_field = None


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`7fbf387c`](https://github.com/kdeldycke/repomatic/commit/7fbf387c72ab503b7bf845692bb58fe0257ac3d2) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/7fbf387c72ab503b7bf845692bb58fe0257ac3d2/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/7fbf387c72ab503b7bf845692bb58fe0257ac3d2/.github/workflows/autofix.yaml) |
| **Run** | [#4511.1](https://github.com/kdeldycke/repomatic/actions/runs/25064819668) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0.dev0`