### PR TITLE
Format Python

### DIFF
--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -182,11 +182,36 @@ def _between(text: str, start: str, end: str) -> str:
 @pytest.mark.parametrize(
     ("md_path", "start", "end", "generator_name"),
     [
-        (CLI_MD, "<!-- cli-reference-start -->", "<!-- cli-reference-end -->", "cli_reference"),
-        (CONFIGURATION_MD, "<!-- config-reference-start -->", "<!-- config-reference-end -->", "config_deflist"),
-        (TOOL_RUNNER_MD, "<!-- tool-summary-start -->", "<!-- tool-summary-end -->", "tool_summary"),
-        (TOOL_RUNNER_MD, "<!-- tool-reference-start -->", "<!-- tool-reference-end -->", "tool_reference"),
-        (INSTALL_MD, "<!-- python-compat-start -->", "<!-- python-compat-end -->", "python_compat_table"),
+        (
+            CLI_MD,
+            "<!-- cli-reference-start -->",
+            "<!-- cli-reference-end -->",
+            "cli_reference",
+        ),
+        (
+            CONFIGURATION_MD,
+            "<!-- config-reference-start -->",
+            "<!-- config-reference-end -->",
+            "config_deflist",
+        ),
+        (
+            TOOL_RUNNER_MD,
+            "<!-- tool-summary-start -->",
+            "<!-- tool-summary-end -->",
+            "tool_summary",
+        ),
+        (
+            TOOL_RUNNER_MD,
+            "<!-- tool-reference-start -->",
+            "<!-- tool-reference-end -->",
+            "tool_reference",
+        ),
+        (
+            INSTALL_MD,
+            "<!-- python-compat-start -->",
+            "<!-- python-compat-end -->",
+            "python_compat_table",
+        ),
     ],
 )
 def test_docs_generator_matches_in_tree_state(


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`623dd5f2`](https://github.com/kdeldycke/repomatic/commit/623dd5f29acc6befc4937f5c88ac89ac073c4a03) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/623dd5f29acc6befc4937f5c88ac89ac073c4a03/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/623dd5f29acc6befc4937f5c88ac89ac073c4a03/.github/workflows/autofix.yaml) |
| **Run** | [#4515.1](https://github.com/kdeldycke/repomatic/actions/runs/25094295434) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0.dev0`