### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -299,11 +299,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
@@ -631,11 +631,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "12.0.2"
+version = "12.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/0c/420cc75c36630d333c10494eb5f87d34eb80918e1a99a63288352d07ae94/extra_platforms-12.0.2.tar.gz", hash = "sha256:4f66c74bdd6fa5b757ce00ab05f7e4de24abd1d06d468161349e86e6928c2123", size = 72988, upload-time = "2026-04-28T15:44:24.926Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f6/a20c4586c9bd653f596258455652725405f4b734e6270f7fc07a1a498932/extra_platforms-12.0.3.tar.gz", hash = "sha256:0a3201a05f93f18c840f3e9970d33f756a621eea719cbdfa24a514f96c79de7e", size = 72879, upload-time = "2026-04-29T06:47:18.131Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/9f/cc755a9279210bbcf552c1a9fca420a7b3526e7fe4d57a2285b6624381c2/extra_platforms-12.0.2-py3-none-any.whl", hash = "sha256:e25d63534dd4e38d01b09b9e340a41a43338be08cbbd7b87dbd8eb18b332e7e3", size = 76128, upload-time = "2026-04-28T15:44:25.951Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ef/efc376476f41868ca834b30ed100b250d53da2b4929ee8e63ef48e7b0b03/extra_platforms-12.0.3-py3-none-any.whl", hash = "sha256:b6b7fad4b41e1f9f161cc74c03d963e43a3a34e0ee1991943314685314b01cf6", size = 76128, upload-time = "2026-04-29T06:47:16.945Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-22`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [certifi](https://pypi.org/project/certifi/) | `2026.2.25` → `2026.4.22` | 2026-04-22 |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`12.0.2` → `12.0.3`](https://github.com/kdeldycke/extra-platforms/compare/v12.0.2...v12.0.3) | 2026-04-29 |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v12.0.3`](https://github.com/kdeldycke/extra-platforms/releases/tag/v12.0.3)

> [!NOTE]
> `12.0.3` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/12.0.3/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v12.0.3).

- Extend missing-shell tolerance to `test_skip_all_shells`, `test_skip_bash`, and `test_skip_powershell` in `tests/test_pytest.py`. The `12.0.2` shell-tolerance work only covered `tests/test_root.py`, leaving these three tests failing on sandboxed builders (Guix, BusyBox-only images) where no shell is detected.

**Full changelog**: [`v12.0.2...v12.0.3`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v12.0.2...v12.0.3)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`a9da5133`](https://github.com/kdeldycke/repomatic/commit/a9da5133413fece630ff5e83586fc8983ed77217) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/a9da5133413fece630ff5e83586fc8983ed77217/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/a9da5133413fece630ff5e83586fc8983ed77217/.github/workflows/autofix.yaml) |
| **Run** | [#4523.1](https://github.com/kdeldycke/repomatic/actions/runs/25108836215) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.1.dev0`