### PR TITLE
Format Python

### DIFF
--- a/repomatic/github/pr_body.py
+++ b/repomatic/github/pr_body.py
@@ -261,9 +261,7 @@ def _substitute(text: str, kwargs: dict[str, str | None]) -> str:
     return text
 
 
-def _render_single(
-    name: str | Path, kwargs: dict[str, str | None]
-) -> tuple[str, bool]:
+def _render_single(name: str | Path, kwargs: dict[str, str | None]) -> tuple[str, bool]:
     """Render a single template and return its body with footer preference.
 
     :param name: Template name without `.md` extension, or a


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`8d883c81`](https://github.com/kdeldycke/repomatic/commit/8d883c81f5c7da5a14b2eddc3c0792a53cf71516) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/8d883c81f5c7da5a14b2eddc3c0792a53cf71516/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/8d883c81f5c7da5a14b2eddc3c0792a53cf71516/.github/workflows/autofix.yaml) |
| **Run** | [#4529.1](https://github.com/kdeldycke/repomatic/actions/runs/25110985053) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.17.0.dev0`