### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -425,7 +425,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.13.0"
+version = "7.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -438,9 +438,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/3b/61fab1784a949eec5337cfd45ceb12f87d12757d0cffac850b50cafc269e/click_extra-7.13.0.tar.gz", hash = "sha256:52b27d746e8254c93320cc463750f376aea45aa61bd0de9a45412f471e54f63e", size = 138062, upload-time = "2026-04-16T16:09:40.328Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/44/e8200fc42682c544c4597f4674910fad1358af63c5b6d45bf89d20a18708/click_extra-7.14.0.tar.gz", hash = "sha256:7e2f83aa631219bcff414208e20bd23d3f1bf92802e2820b3c49a9a87fa5f771", size = 144761, upload-time = "2026-04-24T13:35:04.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/0b/af0f24dfd34ddb2f77c8164ba47b1a8f4a3e6a84ce8d41a414145ca7502d/click_extra-7.13.0-py3-none-any.whl", hash = "sha256:a7abe62dd3c045e4299692e2fe77a274244d46a2b327980b543e45b3dd540e9e", size = 151712, upload-time = "2026-04-16T16:09:38.712Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/50/f5159c0fe0a59b7ad8c1fb12e4133e2b073bc99778d19ab9b111378117d4/click_extra-7.14.0-py3-none-any.whl", hash = "sha256:3aaa50566d44db263db3aed02552c89950b1d09f01df300c041907bcf29882e6", size = 159274, upload-time = "2026-04-24T13:35:05.95Z" },
 ]
 
 [package.optional-dependencies]
@@ -838,11 +838,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.12"
+version = "3.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -877,15 +877,15 @@ wheels = [
 
 [[package]]
 name = "lizard"
-version = "1.22.0"
+version = "1.22.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pathspec" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/5e/8b4f17dcc5ea18562cc4b86d139700d7ac8e877c253dea0d9a4a905fe277/lizard-1.22.0.tar.gz", hash = "sha256:a5f5ef82a9781a93cee163af0aa7eae588238d4827287deb51cae4af73a00b73", size = 90667, upload-time = "2026-04-22T01:46:47.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c7/776f75710b0033d69249b45ed571f8a314c1a8980c1d3c64e3c12f541869/lizard-1.22.1.tar.gz", hash = "sha256:29fe26f3746f8539227ba909a6143c749548690271e13a3f73204b22e2e62590", size = 90616, upload-time = "2026-04-23T01:54:30.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/c2/3f228da174a5e5c554eeba7e33d5d91d8b742255b1d238e66608c284810c/lizard-1.22.0-py2.py3-none-any.whl", hash = "sha256:7601655673c1ebe12fe8d9a9ad6adc132874da108a077efaac9684d02a80e6fc", size = 98704, upload-time = "2026-04-22T01:46:45.554Z" },
+    { url = "https://files.pythonhosted.org/packages/45/aa/54d9292917f0f9cc684fd053f879e3e8292bf4bc40e984d542dbfe393063/lizard-1.22.1-py2.py3-none-any.whl", hash = "sha256:cc629472d4b031f7692bd7f7e78d2574029008148fba75e45f3592774c8e7420", size = 98713, upload-time = "2026-04-23T01:54:29.008Z" },
 ]
 
 [[package]]
@@ -1163,20 +1163,20 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
 name = "pathspec"
-version = "1.0.4"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-26`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | [`7.13.0` → `7.14.0`](https://github.com/kdeldycke/click-extra/compare/v7.13.0...v7.14.0) | 2026-04-24 |
| [idna](https://pypi.org/project/idna/) | [`3.12` → `3.13`](https://github.com/kjd/idna/compare/v3.12...v3.13) | 2026-04-22 |
| [lizard](https://pypi.org/project/lizard/) | `1.22.0` → `1.22.1` | 2026-04-23 |
| [packaging](https://pypi.org/project/packaging/) | [`26.1` → `26.2`](https://github.com/pypa/packaging/compare/26.1...26.2) | 2026-04-24 |
| [pathspec](https://pypi.org/project/pathspec/) | [`1.0.4` → `1.1.0`](https://github.com/cpburnz/python-pathspec/compare/v1.0.4...v1.1.0) | 2026-04-23 |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v7.14.0`](https://github.com/kdeldycke/click-extra/releases/tag/v7.14.0)

> [!NOTE]
> `7.14.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/7.14.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v7.14.0).

- Add `wrap` subcommand: `click-extra wrap SCRIPT [ARGS]...` applies help colorization to any installed Click CLI without modifying its source. Supports `--theme` option and `[tool.click-extra.wrap.<script>]` config sections for persistent CLI defaults. Resolves SCRIPT via console_scripts entry points, `module:function` notation, `.py` file paths, or bare module names. Unknown subcommand names fall through to `wrap` automatically, so `click-extra flask --help` works without typing `wrap`. `run` is kept as an alias.
- Add `show-params` subcommand: `click-extra show-params SCRIPT [SUBCOMMAND]...` introspects any external Click CLI's parameters and displays them as a table. Supports all `--table-format` renderings. Drills into nested subcommands. Auto-discovers the Click command when the entry point is a wrapper function.
- Style `Spec.` column with `option` theme (cyan) and `Python type` with `metavar` theme (cyan dim) in both `--show-params` and `show-params`, matching help-screen conventions.
- Add `get_param_spec()` and `format_param_row()` as public API in `click_extra.parameters`. `get_param_spec()` extracts option-spec strings and handles hidden-param unhiding. `format_param_row()` is the shared cell renderer for both `--show-params` and `show-params` tables.
- Make `ParamStructure.get_param_type()` a `@staticmethod`. Returns `str` for unrecognised custom types instead of raising `ValueError`.
- Replace `render-matrix` subcommand with individual `colors`, `styles`, `palette`, `8color`, and `gradient` subcommands grouped under a "Demo" section. Remove the `click-extra-demo` entry point.
- Move Sphinx tests into `tests/sphinx/`. Downstream packagers can skip them with `--ignore=tests/sphinx` without pulling in Sphinx dependencies.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v7.14.0)

</details>

<details>
<summary><code>idna</code></summary>

[Changelog](https://redirect.github.com/kjd/idna/blob/master/HISTORY.rst)

</details>

<details>
<summary><code>packaging</code></summary>

#### [`26.2`](https://github.com/pypa/packaging/releases/tag/26.2)

## What's Changed

Fixes:

* Fix incorrect sysconfig var name for pyemscripten by @​ryanking13 in https://redirect.github.com/pypa/packaging/pull/1160
* Make `Version`, `Specifier`, `SpecifierSet`, `Tag`, `Marker`, and `Requirement` pickle-safe
  and backward-compatible with pickles created in 25.0-26.1 (including references to the removed
  ``packaging._structures`` module) by @​eachimei and @​henryiii in https://redirect.github.com/pypa/packaging/pull/1163, https://redirect.github.com/pypa/packaging/pull/1168, https://redirect.github.com/pypa/packaging/pull/1170, and https://redirect.github.com/pypa/packaging/pull/1171
* fix: re-export ExceptionGroup for now by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1164

Documentation:

* docs: add errors section and fix missing details by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1159
* docs(dev): document property-based test suite by @​r266-tech in https://redirect.github.com/pypa/packaging/pull/1167
* Fix typo in DirectUrl documentation by @​sbidoul in https://redirect.github.com/pypa/packaging/pull/1169
* docs(specifiers): add is_unsatisfiable() usage example by @​r266-tech in https://redirect.github.com/pypa/packaging/pull/1166

Internal:

* Enable the auditor persona on zizmor by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1158
* Test new pickle guarantees by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1174
* Use native uv integration in rtd by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1175



## New Contributors
* @​ryanking13 made their first contribution in https://redirect.github.com/pypa/packaging/pull/1160
* @​eachimei made their first contribution in https://redirect.github.com/pypa/packaging/pull/1163

**Full Changelog**: https://redirect.github.com/pypa/packaging/compare/26.1...26.2

</details>

<details>
<summary><code>pathspec</code></summary>

#### [`v1.1.0`](https://github.com/cpburnz/python-pathspec/releases/tag/v1.1.0)

Release v1.1.0. See [CHANGES.rst](https://redirect.github.com/cpburnz/python-pathspec/blob/v1.1.0/CHANGES.rst).

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`7f300d6f`](https://github.com/kdeldycke/repomatic/commit/7f300d6fd35bca25e95dd9a296fd7e2445458f68) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/7f300d6fd35bca25e95dd9a296fd7e2445458f68/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/7f300d6fd35bca25e95dd9a296fd7e2445458f68/.github/workflows/autofix.yaml) |
| **Run** | [#4532.1](https://github.com/kdeldycke/repomatic/actions/runs/25284031768) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.17.0.dev0`