### PR TITLE
Format Python

### DIFF
--- a/repomatic/pypi.py
+++ b/repomatic/pypi.py
@@ -105,6 +105,7 @@ def pypi_trusted_publisher_settings_url(
     query = urlencode({"provider": "github", **prefill})
     return f"{base}?{query}"
 
+
 PYPI_LABEL = "🐍 PyPI"
 """Display label for PyPI releases in admonitions."""
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`aa5b5ba7`](https://github.com/kdeldycke/repomatic/commit/aa5b5ba7e3d76efe698a30d5d1e657c402b66748) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/aa5b5ba7e3d76efe698a30d5d1e657c402b66748/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/aa5b5ba7e3d76efe698a30d5d1e657c402b66748/.github/workflows/autofix.yaml) |
| **Run** | [#4547.1](https://github.com/kdeldycke/repomatic/actions/runs/25510201462) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.0.dev0`