### PR TITLE
Format Python

### DIFF
--- a/tests/test_broken_links.py
+++ b/tests/test_broken_links.py
@@ -812,7 +812,13 @@ def test_setup_guide_missing_vt_key_keeps_issue_open(
 @patch("repomatic.cli._token_mod.check_all_pat_permissions")
 @patch("repomatic.cli.check_pypi_trusted_publisher")
 def test_setup_guide_nuitka_disabled_hides_vt_step(
-    mock_pypi, mock_check, mock_branch, mock_lifecycle, _mock_token, tmp_path, monkeypatch
+    mock_pypi,
+    mock_check,
+    mock_branch,
+    mock_lifecycle,
+    _mock_token,
+    tmp_path,
+    monkeypatch,
 ):
     """When Nuitka is disabled, the VT step is omitted from the setup guide."""
     pyproject = tmp_path / "pyproject.toml"

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -51,7 +51,9 @@ class _FakeResponse:
         pass
 
 
-def _patch_pypi_json(payload: Mapping[str, object] | None) -> AbstractContextManager[MagicMock]:
+def _patch_pypi_json(
+    payload: Mapping[str, object] | None,
+) -> AbstractContextManager[MagicMock]:
     """Patch `_fetch_json` to return `payload`."""
     return patch("repomatic.pypi._fetch_json", return_value=payload)
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`02d331c0`](https://github.com/kdeldycke/repomatic/commit/02d331c0adbf75767c437767e585cdf3fc021863) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/02d331c0adbf75767c437767e585cdf3fc021863/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/02d331c0adbf75767c437767e585cdf3fc021863/.github/workflows/autofix.yaml) |
| **Run** | [#4553.1](https://github.com/kdeldycke/repomatic/actions/runs/25513331490) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.0.dev0`