### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -425,7 +425,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.14.1"
+version = "7.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -438,9 +438,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/c9/f02eef46dd487565fac61a0cf7b77bd2c1ce255129bbf04507a6bd3a2cf5/click_extra-7.14.1.tar.gz", hash = "sha256:acfa952375f5051e509643623ef9e66e2691435b9f4ceb50f5fb078e87761028", size = 145060, upload-time = "2026-04-26T20:34:58.762Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/ee/a2bf0ca48304aff973e3d387364f4b60862be8d16247a6101a148cb9a637/click_extra-7.15.0.tar.gz", hash = "sha256:ca56ffd64c3afc5d302c68e894eb955a9457dc5dcb7be9e22d74d2073d1e56ac", size = 157774, upload-time = "2026-05-03T15:40:53.411Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/a4/61d5e395a62cd8e8a8cca9eb4a055666a56841fef11eaa6fbea3d13ac779/click_extra-7.14.1-py3-none-any.whl", hash = "sha256:1dc23b5f0caeade5d643e3f162f3b8b5acef16ee56e39944bbec6744dd2f2e23", size = 159513, upload-time = "2026-04-26T20:34:56.885Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/16/acc727830c736caf93d6ff5ed48454604d47a9541ef703497c408001c8cc/click_extra-7.15.0-py3-none-any.whl", hash = "sha256:71d0299adc92524409f36cee833cc2234aaf048882dd506e7c8172f02d3771e6", size = 176342, upload-time = "2026-05-03T15:40:51.764Z" },
 ]
 
 [package.optional-dependencies]
@@ -1619,11 +1619,11 @@ wheels = [
 
 [[package]]
 name = "pytz"
-version = "2026.1.post1"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
 ]
 
 [[package]]
@@ -2198,11 +2198,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-04`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | [`7.14.1` → `7.15.0`](https://github.com/kdeldycke/click-extra/compare/v7.14.1...v7.15.0) | 2026-05-03 |
| [pytz](https://pypi.org/project/pytz/) | `2026.1.post1` → `2026.2` | 2026-05-04 |
| [wcwidth](https://pypi.org/project/wcwidth/) | [`0.6.0` → `0.7.0`](https://github.com/jquast/wcwidth/compare/0.6.0...0.7.0) | 2026-05-02 |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v7.15.0`](https://github.com/kdeldycke/click-extra/releases/tag/v7.15.0)

> [!NOTE]
> `7.15.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/7.15.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v7.15.0).

- Add opt-in 24-bit true-color rendering to the ANSI Pygments stack. Pass `true_color=True` to `AnsiColorLexer`, `AnsiFilter`, or any session lexer (like `get_lexer_by_name("ansi-shell-session", true_color=True)`) to preserve `SGR 38;2;r;g;b` and `48;2;r;g;b` sequences as `Token.Ansi.FG_{rrggbb}` / `Token.Ansi.BG_{rrggbb}` tokens instead of quantizing them to the 256-color palette. `AnsiHtmlFormatter` renders those tokens as inline `style="color: #rrggbb"` / `style="background-color: #rrggbb"` spans. The default behavior (256-color quantization) is unchanged.
- New `click_extra.theme` module centralizes all theme machinery: `HelpExtraTheme`, `default_theme`, `nocolor_theme`, `OK`, `KO`, `ThemeOption`, `theme_option` decorator, `theme_registry`, and `register_theme()`. Every click-extra command now accepts `--theme [dark|light]`; downstream consumers can extend the choice list via `register_theme()`. The active theme for a CLI run is stored in `ctx.meta[context.THEME]` by `ThemeOption` and retrieved via `get_current_theme()`, so back-to-back invocations in the same process (Sphinx builds, test runners, REPLs) no longer leak `--theme` choices into each other. The `wrap` subcommand reads the theme from the parent group's context rather than carrying its own `--theme`. Adds a corresponding `docs/theme.md` user guide. **Breaking:** downstream code importing theme symbols directly from `click_extra.colorize` must update to `click_extra.theme`; the canonical `from click_extra import HelpExtraTheme` path is unaffected.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v7.15.0)

</details>

<details>
<summary><code>wcwidth</code></summary>

#### [`0.7.0`](https://github.com/jquast/wcwidth/releases/tag/0.7.0)

  * **New** support for kitty text sizing protocol (OSC 66) in `width()` and `clip()`.
  * **New** `clip()` parameter ``control_codes='parse'``, ``'ignore'``, and ``'strict'``. `clip()`
    is now able to clip OSC 8 hyperlinks and OSC 66 text sizing sequences.
  * **Improved** `clip()` and `width()` to support horizontal cursor sequences (``cub``, ``cuf``,
    ``hpa``). Cursor-left (``cub``) or backspace (``\b``) now overwrites text.  column_address
    (``hpa``) and carriage return (``\r``) are now parsed, and more values conditionally raise
    ``ValueError`` when ``control_codes='strict'``.

## PR's

* Remove docs, add utils by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/209
* Bump requests from 2.32.5 to 2.33.0 in /docs by @​dependabot[bot] in https://redirect.github.com/jquast/wcwidth/pull/210
* Bump pygments from 2.19.2 to 2.20.0 in /docs by @​dependabot[bot] in https://redirect.github.com/jquast/wcwidth/pull/212
* dependabot nonsense by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/215
* Expand terminal escape sequence for three more ECMA-48 "families" by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/214
* Improve clip() and width() with hyperlinks and overtyping by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/216
* Improve width() and clip() with kitty Text Sizing Protocol by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/213

**Full Changelog**: https://redirect.github.com/jquast/wcwidth/compare/0.6.0...0.7.0

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`4de4ffc7`](https://github.com/kdeldycke/repomatic/commit/4de4ffc7beae824f9d4ac3492e4d206536a3ff5d) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/4de4ffc7beae824f9d4ac3492e4d206536a3ff5d/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/4de4ffc7beae824f9d4ac3492e4d206536a3ff5d/.github/workflows/autofix.yaml) |
| **Run** | [#4571.1](https://github.com/kdeldycke/repomatic/actions/runs/25673775678) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.3.dev0`