### PR TITLE
Format Python

### DIFF
--- a/repomatic/init_project.py
+++ b/repomatic/init_project.py
@@ -528,9 +528,7 @@ def run_init(
         from .metadata import Metadata
 
         repo_slug = Metadata().repo_slug
-    is_awesome = bool(
-        repo_slug and repo_slug.split("/")[-1].startswith("awesome-")
-    )
+    is_awesome = bool(repo_slug and repo_slug.split("/")[-1].startswith("awesome-"))
     is_python = is_python_project(output_dir)
     logging.debug("Repository traits: awesome=%s python=%s", is_awesome, is_python)
     if is_awesome and not components:

--- a/repomatic/release_prep.py
+++ b/repomatic/release_prep.py
@@ -164,9 +164,7 @@ class ReleasePrep:
         data_dir = repo_root / "repomatic" / "data"
         if not data_dir.exists():
             return []
-        return sorted(
-            path for path in data_dir.glob("*.yaml") if not path.is_symlink()
-        )
+        return sorted(path for path in data_dir.glob("*.yaml") if not path.is_symlink())
 
     def freeze_workflow_urls(self) -> int:
         """Replace workflow URLs from default branch to versioned tag.

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -590,7 +590,9 @@ def test_adds_bumpversion_with_array_sections() -> None:
 def test_returns_none_if_section_exists() -> None:
     """Verify that None is returned if the section already exists."""
     with NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
-        f.write('[project]\nname = "test"\nversion = "0.1.0"\n\n[tool.ruff]\npreview = false\n')
+        f.write(
+            '[project]\nname = "test"\nversion = "0.1.0"\n\n[tool.ruff]\npreview = false\n'
+        )
         f.flush()
         path = Path(f.name)
 
@@ -1589,7 +1591,7 @@ def test_include_config_bypasses_scope_exclusion(
     """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
-        "[tool.repomatic]\ninclude = [\"codecov\"]\n",
+        '[tool.repomatic]\ninclude = ["codecov"]\n',
         encoding="UTF-8",
     )
     monkeypatch.chdir(tmp_path)
@@ -1615,7 +1617,7 @@ def test_include_bypasses_scope_for_bundled_component(
     """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
-        "[tool.repomatic]\ninclude = [\"codecov\"]\n",
+        '[tool.repomatic]\ninclude = ["codecov"]\n',
         encoding="UTF-8",
     )
     monkeypatch.chdir(tmp_path)
@@ -1673,8 +1675,7 @@ def test_file_level_include_bypasses_scope(
     """File-level ``include`` entry bypasses scope for that specific file only."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
-        "[tool.repomatic]\n"
-        'include = ["workflows/changelog.yaml"]\n',
+        '[tool.repomatic]\ninclude = ["workflows/changelog.yaml"]\n',
         encoding="UTF-8",
     )
     monkeypatch.chdir(tmp_path)
@@ -1807,7 +1808,7 @@ def test_include_config_bypasses_python_only_scope(
     """`[tool.repomatic] include` bypasses `RepoScope.PYTHON_ONLY`."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
-        "[tool.repomatic]\ninclude = [\"publish-pypi-action\"]\n",
+        '[tool.repomatic]\ninclude = ["publish-pypi-action"]\n',
         encoding="UTF-8",
     )
     monkeypatch.chdir(tmp_path)
@@ -2667,7 +2668,9 @@ def test_init_reports_unmodified_configs(
     from repomatic.tool_runner import get_data_file_path
 
     pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"\n', encoding="UTF-8")
+    pyproject.write_text(
+        '[project]\nname = "test"\nversion = "0.1.0"\n', encoding="UTF-8"
+    )
     monkeypatch.chdir(tmp_path)
 
     with get_data_file_path("yamllint.yaml") as bundled:
@@ -2683,7 +2686,9 @@ def test_init_no_unmodified_when_different(
 ):
     """Init does not flag modified config files as unmodified."""
     pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"\n', encoding="UTF-8")
+    pyproject.write_text(
+        '[project]\nname = "test"\nversion = "0.1.0"\n', encoding="UTF-8"
+    )
     monkeypatch.chdir(tmp_path)
 
     (tmp_path / ".yamllint.yaml").write_text(

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -56,7 +56,7 @@ def test_get_project_name_with_preloaded_data():
 def test_is_python_project_true_for_pep621(tmp_path):
     """A PEP 621-compliant `[project]` table qualifies as a Python project."""
     (tmp_path / "pyproject.toml").write_text(
-        "[project]\nname = \"orange-grove\"\nversion = \"0.1.0\"\n",
+        '[project]\nname = "orange-grove"\nversion = "0.1.0"\n',
         encoding="UTF-8",
     )
     assert is_python_project(tmp_path) is True
@@ -77,9 +77,7 @@ def test_is_python_project_false_for_missing_pyproject(tmp_path):
 
 def test_is_python_project_false_for_malformed_toml(tmp_path):
     """A `pyproject.toml` that fails to parse is not a Python project."""
-    (tmp_path / "pyproject.toml").write_text(
-        "not = valid = toml\n", encoding="UTF-8"
-    )
+    (tmp_path / "pyproject.toml").write_text("not = valid = toml\n", encoding="UTF-8")
     assert is_python_project(tmp_path) is False
 
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`971b0e40`](https://github.com/kdeldycke/repomatic/commit/971b0e404716018489209e16325a9b0e72c36d2f) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/971b0e404716018489209e16325a9b0e72c36d2f/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/971b0e404716018489209e16325a9b0e72c36d2f/.github/workflows/autofix.yaml) |
| **Run** | [#4581.1](https://github.com/kdeldycke/repomatic/actions/runs/25872282395) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.4.dev0`