### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1486,16 +1486,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.0"
+version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
 ]
 
 [[package]]
@@ -2115,11 +2115,11 @@ wheels = [
 
 [[package]]
 name = "types-boltons"
-version = "25.0.0.20260408"
+version = "25.0.0.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/22/daf1f2431453946a549a67d3f90851d046b19bca6e338f66282f7240c3f8/types_boltons-25.0.0.20260408.tar.gz", hash = "sha256:7b5e7b3083ce4352981bb31174a00b4ee7e0ead67491e697c528d2c751be30d8", size = 21759, upload-time = "2026-04-08T04:33:14.97Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/5a/daec1e65fbbe6672a7e3691f0f989efcf6e0de8c62cf5861d9240ab1e606/types_boltons-25.0.0.20260508.tar.gz", hash = "sha256:c659fbe610768b7c1268d4e7cd0ede5f51cfc10767b76f155f7f9f6442cf08ec", size = 21806, upload-time = "2026-05-08T04:49:52.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/53/d3cf4241c28fc26da978fcee5664e07557f041d4d75e06889aa50b6cdb59/types_boltons-25.0.0.20260408-py3-none-any.whl", hash = "sha256:278663be699cd3482c88f1352a2acbfcd3a93d83d95ff17f77fa2f68f50c3904", size = 28276, upload-time = "2026-04-08T04:33:13.861Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/4cdaf48f900cff162ad9647ab873db2d66d884ac75786d8d9dabe83d45a3/types_boltons-25.0.0.20260508-py3-none-any.whl", hash = "sha256:0153891cadf1924167899d478612072e57631ec93c6731b1bebb69ca24bc63a3", size = 28267, upload-time = "2026-05-08T04:49:51.043Z" },
 ]
 
 [[package]]
@@ -2133,11 +2133,11 @@ wheels = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260408"
+version = "6.0.12.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/6b/f9d82598121b2f0532238381aec27734c24a0ff548ac352b358c2857a176/types_pyyaml-6.0.12.20260508.tar.gz", hash = "sha256:5ae42149c3ebf7aaaf6c65ee49af590c80f0ba52e9e3f75a75c5564b33556fa6", size = 17776, upload-time = "2026-05-08T04:48:28.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/96690460fe7f4e4b4ab0ecd79a8609aec2ae63927ad97625f3c747ca6a1d/types_pyyaml-6.0.12.20260508-py3-none-any.whl", hash = "sha256:edc094ed3a918b0c6232f71a5b67fdf38e76e17517b7d87bfbb9fc27d442fb51", size = 20309, upload-time = "2026-05-08T04:48:27.822Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-08`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [pydantic-settings](https://pypi.org/project/pydantic-settings/) | [`2.14.0` → `2.14.1`](https://github.com/pydantic/pydantic-settings/compare/v2.14.0...v2.14.1) | 2026-05-08 |
| [types-boltons](https://pypi.org/project/types-boltons/) | [`25.0.0.20260408` → `25.0.0.20260508`](https://github.com/python/typeshed/compare/v25.0.0.20260408...v25.0.0.20260508) | 2026-05-08 |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | [`6.0.12.20260408` → `6.0.12.20260508`](https://github.com/python/typeshed/compare/v6.0.12.20260408...v6.0.12.20260508) | 2026-05-08 |

### Release notes

<details>
<summary><code>pydantic-settings</code></summary>

#### [`v2.14.1`](https://github.com/pydantic/pydantic-settings/releases/tag/v2.14.1)

## What's Changed
* Bump the python-packages group with 4 updates by @​dependabot[bot] in https://redirect.github.com/pydantic/pydantic-settings/pull/850
* Bump the python-packages group with 5 updates by @​dependabot[bot] in https://redirect.github.com/pydantic/pydantic-settings/pull/854
* Bump the github-actions group with 3 updates by @​dependabot[bot] in https://redirect.github.com/pydantic/pydantic-settings/pull/853
* Bump the python-packages group with 2 updates by @​dependabot[bot] in https://redirect.github.com/pydantic/pydantic-settings/pull/856
* Fix field named `cls` conflicting with classmethod parameter by @​hramezani in https://redirect.github.com/pydantic/pydantic-settings/pull/858
* Prepare release 2.14.1 by @​hramezani in https://redirect.github.com/pydantic/pydantic-settings/pull/859


**Full Changelog**: https://redirect.github.com/pydantic/pydantic-settings/compare/v2.14.0...v2.14.1

</details>

<details>
<summary><code>types-boltons</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/boltons.md)

</details>

<details>
<summary><code>types-pyyaml</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/PyYAML.md)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`36d285a0`](https://github.com/kdeldycke/repomatic/commit/36d285a098c81522b85b82747d47a09e9b80a688) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/36d285a098c81522b85b82747d47a09e9b80a688/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/36d285a098c81522b85b82747d47a09e9b80a688/.github/workflows/autofix.yaml) |
| **Run** | [#4594.1](https://github.com/kdeldycke/repomatic/actions/runs/25924004883) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.5.dev0`