### PR TITLE
Format Python

### DIFF
--- a/repomatic/metadata.py
+++ b/repomatic/metadata.py
@@ -1256,9 +1256,13 @@ class Metadata:
             )
             return True
 
-        if self.event_type == WorkflowEvent.push and self.head_commit_message and any(
-            self.head_commit_message.startswith(prefix)
-            for prefix in MANUAL_VERSION_BUMP_COMMIT_PREFIXES
+        if (
+            self.event_type == WorkflowEvent.push
+            and self.head_commit_message
+            and any(
+                self.head_commit_message.startswith(prefix)
+                for prefix in MANUAL_VERSION_BUMP_COMMIT_PREFIXES
+            )
         ):
             logging.info(
                 "Head commit is a user-initiated version bump "


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`36d285a0`](https://github.com/kdeldycke/repomatic/commit/36d285a098c81522b85b82747d47a09e9b80a688) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/36d285a098c81522b85b82747d47a09e9b80a688/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/36d285a098c81522b85b82747d47a09e9b80a688/.github/workflows/autofix.yaml) |
| **Run** | [#4594.1](https://github.com/kdeldycke/repomatic/actions/runs/25924004883) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.18.5.dev0`