### PR TITLE
Update docs

### DIFF
--- a/docs/tool-runner.md
+++ b/docs/tool-runner.md
@@ -31,7 +31,7 @@ invoke(repomatic, args=['run', '--list'])
 | :-------------------------------------------------------------------- | :------- | :---------- | :----------------------------------------------------------- |
 | [actionlint](https://github.com/rhysd/actionlint)                     | `1.7.12` | Binary      | `.github/actionlint.yaml`                                    |
 | [autopep8](https://github.com/hhatto/autopep8)                        | `2.3.2`  | PyPI        | CLI flags only                                               |
-| [Biome](https://github.com/biomejs/biome)                             | `2.4.14` | Binary      | `biome.json`, `biome.jsonc`                                  |
+| [Biome](https://github.com/biomejs/biome)                             | `2.4.15` | Binary      | `biome.json`, `biome.jsonc`                                  |
 | [bump-my-version](https://github.com/callowayproject/bump-my-version) | `1.2.7`  | PyPI        | `[tool.bump-my-version]` in `pyproject.toml`                 |
 | [Gitleaks](https://github.com/gitleaks/gitleaks)                      | `8.30.1` | Binary      | `.gitleaks.toml`, `.github/gitleaks.toml`                    |
 | [labelmaker](https://github.com/jwodder/labelmaker)                   | `0.6.4`  | Binary      | CLI flags only                                               |
@@ -255,7 +255,7 @@ For tools with subcommands (ruff, biome, gitleaks), the subcommand goes after `-
 
 ### [Biome](https://github.com/biomejs/biome)
 
-**Installed version:** `2.4.14`
+**Installed version:** `2.4.15`
 
 **Installation method:** Binary (downloaded from GitHub Releases)
 


### PR DESCRIPTION
### Description

Regenerates API documentation with [sphinx-apidoc](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html), converts RST stubs to [MyST markdown](https://myst-parser.readthedocs.io/) if applicable, and runs the project's `docs_update.py` script if present. See the [`update-docs` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`9c564c67`](https://github.com/kdeldycke/repomatic/commit/9c564c67d26b7cf100637b1b06478a1c2fbf0b78) |
| **Job** | [`update-docs`](https://github.com/kdeldycke/repomatic/blob/9c564c67d26b7cf100637b1b06478a1c2fbf0b78/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/9c564c67d26b7cf100637b1b06478a1c2fbf0b78/.github/workflows/autofix.yaml) |
| **Run** | [#4599.1](https://github.com/kdeldycke/repomatic/actions/runs/26173386865) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.19.0.dev0`