### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1808,7 +1808,7 @@ typing = [
 
 [[package]]
 name = "requests"
-version = "2.34.0"
+version = "2.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1816,9 +1816,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/b8/7a707d60fea4c49094e40262cc0e2ca6c768cca21587e34d3f705afec47e/requests-2.34.0.tar.gz", hash = "sha256:7d62fe92f50eb82c529b0916bb445afa1531a566fc8f35ffdc64446e771b856a", size = 142436, upload-time = "2026-05-11T19:29:51.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl", hash = "sha256:917520a21b767485ce7c588f4ebb917c436b24a31231b44228715eaeb5a52c60", size = 73021, upload-time = "2026-05-11T19:29:49.923Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-14`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [requests](https://pypi.org/project/requests/) | [`2.34.0` → `2.34.1`](https://github.com/psf/requests/compare/v2.34.0...v2.34.1) | 2026-05-13 |

### Release notes

<details>
<summary><code>requests</code></summary>

#### [`v2.34.1`](https://github.com/psf/requests/releases/tag/v2.34.1)

2.34.1 (2026-05-13)
-------------------

**Bugfixes**
- Widened `json` input type from `dict` and `list` to `Mapping`
  and `Sequence`. (#​7436)
- Changed `headers` input type to MutableMapping and removed `None` from
  `Request.headers` typing to improve handling for users. (#​7431)
- `Response.reason` moved from `str | None` to `str` to improve handling
  for users. (#​7437)
- Fixed a bug where some bodies with custom `__getattr__` implementations
  weren't being properly detected as Iterables. (#​7433)

## New Contributors
* @​k223kim made their first contribution in https://redirect.github.com/psf/requests/pull/7433

**Full Changelog**: https://redirect.github.com/psf/requests/blob/main/HISTORY.md#2341-2026-05-13

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`cbdd2bcd`](https://github.com/kdeldycke/repomatic/commit/cbdd2bcdc44841755eb677c42becbb3f1f775db7) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/cbdd2bcdc44841755eb677c42becbb3f1f775db7/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/cbdd2bcdc44841755eb677c42becbb3f1f775db7/.github/workflows/autofix.yaml) |
| **Run** | [#4606.1](https://github.com/kdeldycke/repomatic/actions/runs/26211727970) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.19.0.dev0`