### PR TITLE
Format Python

### DIFF
--- a/tests/test_github_releases.py
+++ b/tests/test_github_releases.py
@@ -130,10 +130,13 @@ def test_get_github_releases_raises_on_url_error(monkeypatch):
     silently rewrite the changelog.
     """
     _bypass_cache(monkeypatch)
-    with patch(
-        "repomatic.github.releases.urlopen",
-        side_effect=URLError("502 Bad Gateway"),
-    ), pytest.raises(GitHubReleasesUnavailable) as exc_info:
+    with (
+        patch(
+            "repomatic.github.releases.urlopen",
+            side_effect=URLError("502 Bad Gateway"),
+        ),
+        pytest.raises(GitHubReleasesUnavailable) as exc_info,
+    ):
         get_github_releases("https://github.com/user/repo")
     assert "user/repo" in str(exc_info.value)
 
@@ -158,7 +161,10 @@ def test_get_github_releases_raises_on_partial_pagination(monkeypatch):
         fail_after_first[0] = True
         return next(responses)
 
-    with patch("repomatic.github.releases.urlopen", side_effect=fake_urlopen), pytest.raises(GitHubReleasesUnavailable) as exc_info:
+    with (
+        patch("repomatic.github.releases.urlopen", side_effect=fake_urlopen),
+        pytest.raises(GitHubReleasesUnavailable) as exc_info,
+    ):
         get_github_releases("https://github.com/user/repo")
     assert "page 2" in str(exc_info.value)
 
@@ -166,20 +172,26 @@ def test_get_github_releases_raises_on_partial_pagination(monkeypatch):
 def test_get_github_releases_raises_on_timeout(monkeypatch):
     """A TimeoutError surfaces as GitHubReleasesUnavailable."""
     _bypass_cache(monkeypatch)
-    with patch(
-        "repomatic.github.releases.urlopen",
-        side_effect=TimeoutError("read timed out"),
-    ), pytest.raises(GitHubReleasesUnavailable):
+    with (
+        patch(
+            "repomatic.github.releases.urlopen",
+            side_effect=TimeoutError("read timed out"),
+        ),
+        pytest.raises(GitHubReleasesUnavailable),
+    ):
         get_github_releases("https://github.com/user/repo")
 
 
 def test_get_github_releases_raises_on_invalid_json(monkeypatch):
     """An unparseable response surfaces as GitHubReleasesUnavailable."""
     _bypass_cache(monkeypatch)
-    with patch(
-        "repomatic.github.releases.urlopen",
-        return_value=_FakeResponse(b"not json"),
-    ), pytest.raises(GitHubReleasesUnavailable):
+    with (
+        patch(
+            "repomatic.github.releases.urlopen",
+            return_value=_FakeResponse(b"not json"),
+        ),
+        pytest.raises(GitHubReleasesUnavailable),
+    ):
         get_github_releases("https://github.com/user/repo")
 
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`ca6d8e16`](https://github.com/kdeldycke/repomatic/commit/ca6d8e168e5e5c5bcadba1eda8a2d43fe8132f74) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/ca6d8e168e5e5c5bcadba1eda8a2d43fe8132f74/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/ca6d8e168e5e5c5bcadba1eda8a2d43fe8132f74/.github/workflows/autofix.yaml) |
| **Run** | [#4610.1](https://github.com/kdeldycke/repomatic/actions/runs/26229456381) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.19.0.dev0`