### PR TITLE
Format Python

### DIFF
--- a/repomatic/cli.py
+++ b/repomatic/cli.py
@@ -899,9 +899,7 @@ def version_check(part: str) -> None:
     echo("true" if allowed else "false")
 
 
-@repomatic.command(
-    short_help="Close a stale version-bump PR", section=_section_release
-)
+@repomatic.command(short_help="Close a stale version-bump PR", section=_section_release)
 @option(
     "--part",
     type=Choice(["minor", "major"], case_sensitive=False),

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -36,7 +36,9 @@ def test_list_open_prs_by_branch_filters_arguments():
     args = mock_gh.call_args.args[0]
     assert args[:2] == ["pr", "list"]
     assert "--state" in args and args[args.index("--state") + 1] == "open"
-    assert "--head" in args and args[args.index("--head") + 1] == "minor-version-increment"
+    assert (
+        "--head" in args and args[args.index("--head") + 1] == "minor-version-increment"
+    )
 
 
 def test_list_open_prs_by_branch_empty():


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`48bbf4b7`](https://github.com/kdeldycke/repomatic/commit/48bbf4b767ce15e5cbd389ad3b6f544fb8f67529) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/48bbf4b767ce15e5cbd389ad3b6f544fb8f67529/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/48bbf4b767ce15e5cbd389ad3b6f544fb8f67529/.github/workflows/autofix.yaml) |
| **Run** | [#4614.1](https://github.com/kdeldycke/repomatic/actions/runs/26244397169) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.19.0.dev0`