### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.15.0"
+version = "7.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -437,9 +437,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/ee/a2bf0ca48304aff973e3d387364f4b60862be8d16247a6101a148cb9a637/click_extra-7.15.0.tar.gz", hash = "sha256:ca56ffd64c3afc5d302c68e894eb955a9457dc5dcb7be9e22d74d2073d1e56ac", size = 157774, upload-time = "2026-05-03T15:40:53.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/31/625badaa39e3e5cf320471117fee259327280285de23a8112d3571dad934/click_extra-7.16.0.tar.gz", hash = "sha256:275659ab92c6f0e23fcd3530025e37b568a21d5f5a595ae48ed59771fd7e37a5", size = 190036, upload-time = "2026-05-14T19:48:42.78Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/16/acc727830c736caf93d6ff5ed48454604d47a9541ef703497c408001c8cc/click_extra-7.15.0-py3-none-any.whl", hash = "sha256:71d0299adc92524409f36cee833cc2234aaf048882dd506e7c8172f02d3771e6", size = 176342, upload-time = "2026-05-03T15:40:51.764Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6a/fe2586a249dcc30ff73e4b53bfc8c470919af1e3213f3f5daf8cf821acdd/click_extra-7.16.0-py3-none-any.whl", hash = "sha256:be6014bdd1f1867cd1868b3220df33e10557577f7fe94de6e9429aabdec7d7d7", size = 208231, upload-time = "2026-05-14T19:48:41.178Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-14`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | [`7.15.0` → `7.16.0`](https://github.com/kdeldycke/click-extra/compare/v7.15.0...v7.16.0) | 2026-05-14 |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v7.16.0`](https://github.com/kdeldycke/click-extra/releases/tag/v7.16.0)

> [!NOTE]
> `7.16.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/7.16.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v7.16.0).

- Theme system overhaul. Four branded palettes join the built-in catalog: `solarized_dark` (Ethan Schoonover), `dracula` (Zeno Rocha), `nord` (Arctic Ice Studio), and `monokai` (Wimer Hazenberg), hand-curated for the semantic roles click-extra exposes (option, metavar, choice, deprecated, envvar, …). The full catalog now ships as `click_extra/themes.toml` (a TOML data file) instead of Python subclasses, loaded at import time via `importlib.resources` for proper wheel/zipapp support. `BUILTIN_THEMES` is the single public dict of `{name: HelpExtraTheme}`; access individual palettes via `BUILTIN_THEMES["dark"]`, `BUILTIN_THEMES["solarized_dark"]`, etc. Adding a built-in theme is a one-file data edit: declare a `[<name>]` table with one inline-table per styled slot, no Python needed. **Breaking:** the `click_extra.themes` module is removed (import from `click_extra` or `click_extra.theme`); the six per-theme UPPER_CASE constants (`DARK`, `DRACULA`, `LIGHT`, `MONOKAI`, `NORD`, `SOLARIZED_DARK`) are removed (use `BUILTIN_THEMES["<name>"]` instead).
- **Breaking:** `default_theme` module attribute replaced by the `get_default_theme()` / `set_default_theme(theme)` accessors. The previous module-attribute pattern silently froze whatever was bound at import time when consumers (e.g. `ExtraVersionOption`'s style defaults) captured `default_theme.invoked_command` as a default function parameter, so later overrides via `wrap.patch_click()` didn't propagate. The function pair always observes the current value. `click_extra.wrap.patch_click()` now calls `set_default_theme()`.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v7.16.0)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e00dd49b`](https://github.com/kdeldycke/repomatic/commit/e00dd49b4fab9fe88dde567ce78cfe9628966f60) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/e00dd49b4fab9fe88dde567ce78cfe9628966f60/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/e00dd49b4fab9fe88dde567ce78cfe9628966f60/.github/workflows/autofix.yaml) |
| **Run** | [#4617.1](https://github.com/kdeldycke/repomatic/actions/runs/26250200369) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.19.0.dev0`