### PR TITLE
Bump minor version to `v6.20.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`6.19.1.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v6.19.0...main)
+## [`6.20.0.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v6.19.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "repomatic"
-version = "6.19.1.dev0"
+version = "6.20.0.dev0"
 description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 readme = "readme.md"
 keywords = [
@@ -124,7 +124,7 @@ repomatic = "repomatic.__main__:main"
 [project.urls]
 "Changelog" = "https://github.com/kdeldycke/repomatic/blob/main/changelog.md"
 "Documentation" = "https://kdeldycke.github.io/repomatic"
-"Download" = "https://github.com/kdeldycke/repomatic/releases/tag/v6.19.1.dev0"
+"Download" = "https://github.com/kdeldycke/repomatic/releases/tag/v6.20.0.dev0"
 "Funding" = "https://github.com/sponsors/kdeldycke"
 "Homepage" = "https://github.com/kdeldycke/repomatic"
 "Issues" = "https://github.com/kdeldycke/repomatic/issues"
@@ -289,7 +289,7 @@ run.source = [ "repomatic" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "6.19.1.dev0"
+current_version = "6.20.0.dev0"
 allow_dirty = true
 ignore_missing_files = true
 # Parse versions with an optional .devN suffix (PEP 440).

--- a/repomatic/__init__.py
+++ b/repomatic/__init__.py
@@ -17,5 +17,5 @@
 
 from __future__ import annotations
 
-__version__ = "6.19.1.dev0"
+__version__ = "6.20.0.dev0"
 __git_tag_sha__ = ""

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.16.0"
+version = "7.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -437,9 +437,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/31/625badaa39e3e5cf320471117fee259327280285de23a8112d3571dad934/click_extra-7.16.0.tar.gz", hash = "sha256:275659ab92c6f0e23fcd3530025e37b568a21d5f5a595ae48ed59771fd7e37a5", size = 190036, upload-time = "2026-05-14T19:48:42.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/02/d180104019150d340049dccc41f17d9ba0c3363c44767b01b029716d259b/click_extra-7.16.1.tar.gz", hash = "sha256:a616651275a9673ed4930976a1d6bdd93dc04325cf475ccc38399b0c4396644e", size = 190154, upload-time = "2026-05-15T06:53:28.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/6a/fe2586a249dcc30ff73e4b53bfc8c470919af1e3213f3f5daf8cf821acdd/click_extra-7.16.0-py3-none-any.whl", hash = "sha256:be6014bdd1f1867cd1868b3220df33e10557577f7fe94de6e9429aabdec7d7d7", size = 208231, upload-time = "2026-05-14T19:48:41.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/91/81c0dacf90bc8d9f778ef74e3993cad0e7c99647afd7352a6e9769c0398c/click_extra-7.16.1-py3-none-any.whl", hash = "sha256:d83cb123f82f13d95bc5d0ffa3d049c3bcdb55278105d0a77059eb0735e9286e", size = 208248, upload-time = "2026-05-15T06:53:26.535Z" },
 ]
 
 [package.optional-dependencies]
@@ -1717,7 +1717,7 @@ wheels = [
 
 [[package]]
 name = "repomatic"
-version = "6.19.1.dev0"
+version = "6.20.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

### To bump version to `v6.20.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`b4ae0d8c`](https://github.com/kdeldycke/repomatic/commit/b4ae0d8c71929312e6045b91aec7c230c38c6d36) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/repomatic/blob/b4ae0d8c71929312e6045b91aec7c230c38c6d36/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/b4ae0d8c71929312e6045b91aec7c230c38c6d36/.github/workflows/changelog.yaml) |
| **Run** | [#4140.1](https://github.com/kdeldycke/repomatic/actions/runs/26367314139) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.20.0.dev0`