### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.16.0"
+version = "7.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -437,9 +437,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/31/625badaa39e3e5cf320471117fee259327280285de23a8112d3571dad934/click_extra-7.16.0.tar.gz", hash = "sha256:275659ab92c6f0e23fcd3530025e37b568a21d5f5a595ae48ed59771fd7e37a5", size = 190036, upload-time = "2026-05-14T19:48:42.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/02/d180104019150d340049dccc41f17d9ba0c3363c44767b01b029716d259b/click_extra-7.16.1.tar.gz", hash = "sha256:a616651275a9673ed4930976a1d6bdd93dc04325cf475ccc38399b0c4396644e", size = 190154, upload-time = "2026-05-15T06:53:28.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/6a/fe2586a249dcc30ff73e4b53bfc8c470919af1e3213f3f5daf8cf821acdd/click_extra-7.16.0-py3-none-any.whl", hash = "sha256:be6014bdd1f1867cd1868b3220df33e10557577f7fe94de6e9429aabdec7d7d7", size = 208231, upload-time = "2026-05-14T19:48:41.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/91/81c0dacf90bc8d9f778ef74e3993cad0e7c99647afd7352a6e9769c0398c/click_extra-7.16.1-py3-none-any.whl", hash = "sha256:d83cb123f82f13d95bc5d0ffa3d049c3bcdb55278105d0a77059eb0735e9286e", size = 208248, upload-time = "2026-05-15T06:53:26.535Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-17`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | [`7.16.0` → `7.16.1`](https://github.com/kdeldycke/click-extra/compare/v7.16.0...v7.16.1) | 2026-05-15 |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v7.16.1`](https://github.com/kdeldycke/click-extra/releases/tag/v7.16.1)

> [!NOTE]
> `7.16.1` is available on [🐍 PyPI](https://pypi.org/project/click-extra/7.16.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v7.16.1).

- Fix `ConfigOption` mutating its cached `params_template` when merging user configuration. `_recursive_update` updates its first argument in place, so back-to-back invocations of the same CLI (Sphinx builds, test runners, REPLs) leaked keys set by an earlier `--config` into the current invocation's `default_map`. Both the `--config` load path and `--validate-config` now pass a deep copy of the template.

**Full changelog**: [`v7.16.0...v7.16.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v7.16.0...v7.16.1)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-7.16.1-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v7.16.1/click-extra-7.16.1-linux-arm64.bin) | 1 / 63 | [View scan](https://www.virustotal.com/gui/file/1cf1938838613effafaa2b50448e8941629f7fa8a1d300f1dc89782943c4c23b) |
| [`click-extra-7.16.1-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v7.16.1/click-extra-7.16.1-linux-x64.bin) | 1 / 64 | [View scan](https://www.virustotal.com/gui/file/dcfdea45fd01656d8c70d347f78a7383d7bfd7375a25218a23e173d026e0b5f7) |
| [`click-extra-7.16.1-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v7.16.1/click-extra-7.16.1-macos-arm64.bin) | 1 / 62 | [View scan](https://www.virustotal.com/gui/file/7e93fb71c70cea5eec6828ecb54c39086966d19dcad218e953abf8951e48d488) |
| [`click-extra-7.16.1-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v7.16.1/click-extra-7.16.1-macos-x64.bin) | 0 / 63 | [View scan](https://www.virustotal.com/gui/file/3a600cdb1aaa6ebb430f7649f762d1d6e002dadd8b23a3d36bd5030d56755a89) |

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v7.16.1)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`55d38252`](https://github.com/kdeldycke/repomatic/commit/55d382527dfe73bfe8cbb13e06fd5918e98a18f7) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/55d382527dfe73bfe8cbb13e06fd5918e98a18f7/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/55d382527dfe73bfe8cbb13e06fd5918e98a18f7/.github/workflows/autofix.yaml) |
| **Run** | [#4627.1](https://github.com/kdeldycke/repomatic/actions/runs/26367480467) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.19.1.dev0`