### PR TITLE
Typo

### DIFF
--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -1088,10 +1088,10 @@ PYPROJECT_WITH_TYPOS = """\
 files.extend-exclude = ["assets/Monokai Soda.terminal"]
 
 [tool.typos.default.extend-identifiers]
-automaticEmojiSubstitutionEnablediMessage = "automaticEmojiSubstitutionEnablediMessage"
+automaticEmojiSubstitutionEnabledMessage = "automaticEmojiSubstitutionEnabledMessage"
 
 [tool.typos.default.extend-words]
-Sur = "Sur"
+Sure = "Sure"
 """
 
 
@@ -1415,9 +1415,9 @@ def test_syncs_typos_identifiers_into_existing_section(tmp_path: Path) -> None:
     identifiers = tomllib.loads(result)["tool"]["typos"]["default"][
         "extend-identifiers"
     ]
-    assert identifiers["Github"] == "GitHub"
-    assert identifiers["MacOS"] == "macOS"
-    assert identifiers["PyPi"] == "PyPI"
+    assert identifiers["GitHub"] == "GitHub"
+    assert identifiers["macOS"] == "macOS"
+    assert identifiers["PyPI"] == "PyPI"
 
 
 def test_typos_preserves_local_inline_table_keys(tmp_path: Path) -> None:
@@ -1431,10 +1431,10 @@ def test_typos_preserves_local_inline_table_keys(tmp_path: Path) -> None:
     default = tomllib.loads(result)["tool"]["typos"]["default"]
     # Local additions kept.
     assert (
-        default["extend-identifiers"]["automaticEmojiSubstitutionEnablediMessage"]
-        == "automaticEmojiSubstitutionEnablediMessage"
+        default["extend-identifiers"]["automaticEmojiSubstitutionEnabledMessage"]
+        == "automaticEmojiSubstitutionEnabledMessage"
     )
-    assert default["extend-words"]["Sur"] == "Sur"
+    assert default["extend-words"]["Sure"] == "Sure"
     # Template entries present too.
     assert default["extend-words"]["astroid"] == "astroid"
     assert default["extend-ignore-re"]
@@ -1454,7 +1454,7 @@ def test_typos_preserves_local_only_table(tmp_path: Path) -> None:
 
 def test_typos_canonical_value_wins_on_conflict(tmp_path: Path) -> None:
     """Canonical capitalization overrides a wrong local target on shared keys."""
-    content = '[tool.typos.default.extend-identifiers]\nGithub = "Github"\n'
+    content = '[tool.typos.default.extend-identifiers]\nGithub = "GitHub"\n'
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(content, encoding="UTF-8")
 
@@ -1464,7 +1464,7 @@ def test_typos_canonical_value_wins_on_conflict(tmp_path: Path) -> None:
     identifiers = tomllib.loads(result)["tool"]["typos"]["default"][
         "extend-identifiers"
     ]
-    assert identifiers["Github"] == "GitHub"
+    assert identifiers["GitHub"] == "GitHub"
 
 
 def test_typos_update_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
### Description

Fixes typos detected by [typos](https://github.com/crate-ci/typos). See the [`fix-typos` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Manage false positives and customize spell-checking rules via [`[tool.typos]`](https://github.com/crate-ci/typos/blob/master/docs/reference.md) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e196ea92`](https://github.com/kdeldycke/repomatic/commit/e196ea928e06c22205ffece07606c4e4b0f80e2d) |
| **Job** | [`fix-typos`](https://github.com/kdeldycke/repomatic/blob/e196ea928e06c22205ffece07606c4e4b0f80e2d/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/e196ea928e06c22205ffece07606c4e4b0f80e2d/.github/workflows/autofix.yaml) |
| **Run** | [#4629.1](https://github.com/kdeldycke/repomatic/actions/runs/26367603226) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.20.0.dev0`