### PR TITLE
Format Python

### DIFF
--- a/tests/test_tool_runner.py
+++ b/tests/test_tool_runner.py
@@ -1473,7 +1473,9 @@ def test_run_tool_mypy_without_computed_params(
 
 @patch("repomatic.tool_runner.subprocess.run")
 @patch("repomatic.tool_runner.is_github_ci", return_value=False)
-def test_run_tool_nuitka_uses_module_invocation(mock_ci, mock_run, tmp_path, monkeypatch):
+def test_run_tool_nuitka_uses_module_invocation(
+    mock_ci, mock_run, tmp_path, monkeypatch
+):
     """nuitka runs via `python -m nuitka` to avoid Windows script resolution issues."""
     monkeypatch.chdir(tmp_path)
     mock_run.return_value = MagicMock(returncode=0)


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`c8610cfd`](https://github.com/kdeldycke/repomatic/commit/c8610cfdd4bd07391375ebb3cd0f9544cbb736c7) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/c8610cfdd4bd07391375ebb3cd0f9544cbb736c7/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/c8610cfdd4bd07391375ebb3cd0f9544cbb736c7/.github/workflows/autofix.yaml) |
| **Run** | [#4632.1](https://github.com/kdeldycke/repomatic/actions/runs/26368972055) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.20.0.dev0`