### PR TITLE
Sync `bump-my-version` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,13 +323,9 @@ glob = "./**/__init__.py"
 ignore_missing_version = true
 
 [[tool.bumpversion.files]]
-# Update version in [project] section. Anchored to a line start (regex) so it
-# does not also match the file-version/product-version keys in [tool.nuitka],
-# which contain `version = "X"` as a substring (their values collide with the
-# package version on release commits, where the .devN suffix is absent).
+# Update version in [project] section.
 filename = "./pyproject.toml"
-regex = true
-search = '(?m)^version = "{current_version}"'
+search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
 
 [[tool.bumpversion.files]]
@@ -337,15 +333,6 @@ replace = 'version = "{new_version}"'
 filename = "./pyproject.toml"
 search = "releases/tag/v{current_version}"
 replace = "releases/tag/v{new_version}"
-
-[[tool.bumpversion.files]]
-# Keep the numeric file-version/product-version in [tool.nuitka] in sync. Nuitka
-# rejects PEP 440 .devN suffixes, so the file-specific serialize strips them; the
-# `-version = "` prefix matches both keys at once.
-filename = "./pyproject.toml"
-serialize = [ "{major}.{minor}.{patch}" ]
-search = '-version = "{current_version}"'
-replace = '-version = "{new_version}"'
 
 [[tool.bumpversion.files]]
 # Update the version in Markdown changelog.
@@ -365,6 +352,25 @@ filename = "./citation.cff"
 regex = true
 search = "date-released: \\d{{4}}-\\d{{2}}-\\d{{2}}"
 replace = "date-released: {utcnow:%Y-%m-%d}"
+
+[[tool.bumpversion.files]]
+# Update version in [project] section. Anchored to a line start (regex) so it
+# does not also match the file-version/product-version keys in [tool.nuitka],
+# which contain `version = "X"` as a substring (their values collide with the
+# package version on release commits, where the .devN suffix is absent).
+filename = "./pyproject.toml"
+regex = true
+search = '(?m)^version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+# Keep the numeric file-version/product-version in [tool.nuitka] in sync. Nuitka
+# rejects PEP 440 .devN suffixes, so the file-specific serialize strips them; the
+# `-version = "` prefix matches both keys at once.
+filename = "./pyproject.toml"
+serialize = [ "{major}.{minor}.{patch}" ]
+search = '-version = "{current_version}"'
+replace = '-version = "{new_version}"'
 
 [tool.mypy]
 check_untyped_defs = true


### PR DESCRIPTION
### Description

Initializes the `[tool.bumpversion]` configuration in `pyproject.toml` from the [bundled template](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/bumpversion.toml). See the [`sync-bumpversion` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`bumpversion.sync`](https://kdeldycke.github.io/repomatic/configuration.html#bumpversion-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`191b31b3`](https://github.com/kdeldycke/repomatic/commit/191b31b3d207f719fe1bebc6f36c452069250248) |
| **Job** | [`sync-bumpversion`](https://github.com/kdeldycke/repomatic/blob/191b31b3d207f719fe1bebc6f36c452069250248/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/191b31b3d207f719fe1bebc6f36c452069250248/.github/workflows/autofix.yaml) |
| **Run** | [#4638.1](https://github.com/kdeldycke/repomatic/actions/runs/26370966575) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.20.0.dev0`