### PR TITLE
Format Python

### DIFF
--- a/repomatic/init_project.py
+++ b/repomatic/init_project.py
@@ -329,11 +329,15 @@ def _graft_local_additions(
             # Slots already claimed by the canonical template: a local entry
             # mapping to one of these is a (possibly stale) copy of a template
             # entry, so the template wins and the local copy is not re-added.
-            template_slots = {
-                _entry_identity(item, identity_keys)
-                for item in template_value
-                if isinstance(item, dict)
-            } if identity_keys else set()
+            template_slots = (
+                {
+                    _entry_identity(item, identity_keys)
+                    for item in template_value
+                    if isinstance(item, dict)
+                }
+                if identity_keys
+                else set()
+            )
             # Array in both: append local-only items, preserving their order.
             for index, item in enumerate(existing_value):
                 if (


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`247a6147`](https://github.com/kdeldycke/repomatic/commit/247a614718132da54c83e48371b4e29917cc9258) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/247a614718132da54c83e48371b4e29917cc9258/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/247a614718132da54c83e48371b4e29917cc9258/.github/workflows/autofix.yaml) |
| **Run** | [#4639.1](https://github.com/kdeldycke/repomatic/actions/runs/26372072514) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.20.0.dev0`