### PR TITLE
Format Python

### DIFF
--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -722,13 +722,16 @@ ACTIONS_DIR = REPO_ROOT / ".github" / "actions"
 _UNBUNDLED_ENGINE_LANES = frozenset(RELEASE_ENGINE_WORKFLOWS) - set(
     WORKFLOW_SOURCES.values()
 )
-WORKFLOWS_WITHOUT_SYMLINKS = frozenset((
-    # repomatic's own release entry; downstreams get a generated release.yaml
-    # (assembled from the bundled release.yaml), so the entry isn't bundled.
-    "release.yaml",
-    # Patches repomatic/tool_runner.py, which only exists here.
-    "update-checksums.yaml",
-)) | _UNBUNDLED_ENGINE_LANES
+WORKFLOWS_WITHOUT_SYMLINKS = (
+    frozenset((
+        # repomatic's own release entry; downstreams get a generated release.yaml
+        # (assembled from the bundled release.yaml), so the entry isn't bundled.
+        "release.yaml",
+        # Patches repomatic/tool_runner.py, which only exists here.
+        "update-checksums.yaml",
+    ))
+    | _UNBUNDLED_ENGINE_LANES
+)
 
 
 def test_all_workflows_have_symlinks_in_data() -> None:


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`4bb792e5`](https://github.com/kdeldycke/repomatic/commit/4bb792e5cfd59743b5c6d2470861e1894fd51858) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/4bb792e5cfd59743b5c6d2470861e1894fd51858/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/4bb792e5cfd59743b5c6d2470861e1894fd51858/.github/workflows/autofix.yaml) |
| **Run** | [#4702.1](https://github.com/kdeldycke/repomatic/actions/runs/26573069707) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.24.0.dev0`