### PR TITLE
Format Python

### DIFF
--- a/repomatic/uv.py
+++ b/repomatic/uv.py
@@ -292,9 +292,7 @@ def format_vulnerability_table(vulns: list[VulnerablePackage]) -> str:
 # pyproject.toml exclude-newer-package management
 # ---------------------------------------------------------------------------
 
-_RELATIVE_DURATION_RE = re.compile(
-    r"^(\d+)\s+(seconds?|minutes?|hours?|days?|weeks?)$"
-)
+_RELATIVE_DURATION_RE = re.compile(r"^(\d+)\s+(seconds?|minutes?|hours?|days?|weeks?)$")
 """Matches uv's "friendly" relative duration syntax.
 
 Accepts `N second(s)`, `N minute(s)`, `N hour(s)`, `N day(s)`, and


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`7b9fad50`](https://github.com/kdeldycke/repomatic/commit/7b9fad507bc5a2c506f89f2f7f1190ea306d9ba6) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/7b9fad507bc5a2c506f89f2f7f1190ea306d9ba6/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/7b9fad507bc5a2c506f89f2f7f1190ea306d9ba6/.github/workflows/autofix.yaml) |
| **Run** | [#4720.1](https://github.com/kdeldycke/repomatic/actions/runs/27269435443) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.24.1.dev0`