### PR TITLE
Format Python

### DIFF
--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -3573,9 +3573,7 @@ def test_init_awesome_template_not_auto_included_with_explicit_components(
 # meets those invariants natively, so a future regression cannot silently
 # corrupt a downstream pyproject.toml.
 
-_TOOL_CONFIG_COMPONENTS = [
-    c for c in COMPONENTS if isinstance(c, ToolConfigComponent)
-]
+_TOOL_CONFIG_COMPONENTS = [c for c in COMPONENTS if isinstance(c, ToolConfigComponent)]
 
 
 @pytest.mark.parametrize(
@@ -3647,9 +3645,7 @@ def test_update_tool_config_section_header_whitespace(
         f"section header without preceding blank line at offset "
         f"{no_blank.start() if no_blank else -1} in {comp.name} output"
     )
-    assert "\n\n\n" not in result, (
-        f"triple blank line in {comp.name} output"
-    )
+    assert "\n\n\n" not in result, f"triple blank line in {comp.name} output"
 
 
 def test_tomlrt_aot_only_section_overwrite_invariant() -> None:
@@ -3675,9 +3671,7 @@ def test_tomlrt_aot_only_section_overwrite_invariant() -> None:
     import tomlrt
     from tomlrt import Table
 
-    src = (
-        '[project]\nname = "demo"\n\n[[tool.example.items]]\nkey = "existing"\n'
-    )
+    src = '[project]\nname = "demo"\n\n[[tool.example.items]]\nkey = "existing"\n'
     doc = tomlrt.loads(src)
     new_section = Table.section(tomlrt.loads('[[items]]\nkey = "template"\n'))
     for entry in doc["tool"]["example"]["items"]:


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`3d0d2f3c`](https://github.com/kdeldycke/repomatic/commit/3d0d2f3c34f617a2d77751b394f934dcd0df2e85) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/3d0d2f3c34f617a2d77751b394f934dcd0df2e85/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/3d0d2f3c34f617a2d77751b394f934dcd0df2e85/.github/workflows/autofix.yaml) |
| **Run** | [#4751.1](https://github.com/kdeldycke/repomatic/actions/runs/27429938800) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.0.dev0`