### PR TITLE
Sync `bump-my-version` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,7 +322,6 @@ report.precision = 2
 current_version = "6.25.0.dev0"
 allow_dirty = true
 ignore_missing_files = true
-# Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [
   "{major}.{minor}.{patch}.dev{dev}",


### PR DESCRIPTION
### Description

Initializes the `[tool.bumpversion]` configuration in `pyproject.toml` from the [bundled template](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/bumpversion.toml). See the [`sync-bumpversion` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`bumpversion.sync`](https://kdeldycke.github.io/repomatic/configuration.html#bumpversion-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`27cc8f71`](https://github.com/kdeldycke/repomatic/commit/27cc8f71b63d93cacdfdfbb69e98817ac1471d5f) |
| **Job** | [`sync-bumpversion`](https://github.com/kdeldycke/repomatic/blob/27cc8f71b63d93cacdfdfbb69e98817ac1471d5f/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/27cc8f71b63d93cacdfdfbb69e98817ac1471d5f/.github/workflows/autofix.yaml) |
| **Run** | [#4764.1](https://github.com/kdeldycke/repomatic/actions/runs/27454173724) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.0.dev0`