### PR TITLE
Format Python

### DIFF
--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -1467,9 +1467,7 @@ def test_syncs_typos_identifiers_into_existing_section(tmp_path: Path) -> None:
     result = init_config("typos", pyproject)
 
     assert result is not None
-    identifiers = tomlrt.loads(result)["tool"]["typos"]["default"][
-        "extend-identifiers"
-    ]
+    identifiers = tomlrt.loads(result)["tool"]["typos"]["default"]["extend-identifiers"]
     # Compared against the bundled template so the misspelled canonical keys
     # never appear as literals here, where `fix-typos` would "correct" them.
     assert _canonical_typos_identifiers().items() <= identifiers.items()
@@ -1519,9 +1517,7 @@ def test_typos_canonical_value_wins_on_conflict(tmp_path: Path) -> None:
     result = init_config("typos", pyproject)
 
     assert result is not None
-    identifiers = tomlrt.loads(result)["tool"]["typos"]["default"][
-        "extend-identifiers"
-    ]
+    identifiers = tomlrt.loads(result)["tool"]["typos"]["default"]["extend-identifiers"]
     assert identifiers[key] == canonical
 
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`fbe5a7d8`](https://github.com/kdeldycke/repomatic/commit/fbe5a7d87796a4da7a37177de6cbf9781bfd6a47) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/fbe5a7d87796a4da7a37177de6cbf9781bfd6a47/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/fbe5a7d87796a4da7a37177de6cbf9781bfd6a47/.github/workflows/autofix.yaml) |
| **Run** | [#4755.1](https://github.com/kdeldycke/repomatic/actions/runs/27430336951) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.0.dev0`