### PR TITLE
Format Python

### DIFF
--- a/repomatic/init_project.py
+++ b/repomatic/init_project.py
@@ -1130,7 +1130,9 @@ def _render_file_rule_group(group: dict[str, Any], label: str) -> dict[str, Any]
     for key in group:
         if key not in FILE_RULE_MATCHER_KEYS:
             logging.warning(
-                "Unknown file rule key %r in label %r (ignored).", key, label,
+                "Unknown file rule key %r in label %r (ignored).",
+                key,
+                label,
             )
     changed_files: list[dict[str, list[str]]] = []
     for key in FILE_RULE_CHANGED_FILES_MATCHERS:
@@ -1154,7 +1156,9 @@ def _render_file_rule_group(group: dict[str, Any], label: str) -> dict[str, Any]
                 sub_groups.append(sub_rendered)
             else:
                 logging.warning(
-                    "Skipping empty %r sub-group for label %r.", wrapper, label,
+                    "Skipping empty %r sub-group for label %r.",
+                    wrapper,
+                    label,
                 )
         if sub_groups:
             rendered[wrapper] = sub_groups

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -25,9 +25,8 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 import tomlrt
-from packaging.version import InvalidVersion, Version
-
 import yaml
+from packaging.version import InvalidVersion, Version
 
 from repomatic import __version__
 from repomatic.config import Config, LabelsConfig
@@ -880,9 +879,7 @@ def test_init_labels_appends_structured_rules(tmp_path: Path):
         },
     ]
 
-    content_yaml = (
-        tmp_path / ".github" / "labeller-content-based.yaml"
-    ).read_text()
+    content_yaml = (tmp_path / ".github" / "labeller-content-based.yaml").read_text()
     content_parsed = yaml.safe_load(content_yaml)
     assert content_parsed["🔌 bar-plugin"] == ["xbar", "swiftbar"]
 

--- a/tests/test_labeller_rules.py
+++ b/tests/test_labeller_rules.py
@@ -28,7 +28,6 @@ from repomatic.init_project import (
     _serialize_file_rules,
 )
 
-
 # -- File rules ---------------------------------------------------------------
 
 
@@ -124,7 +123,9 @@ def test_serialize_file_rules_skips_unlabeled(caplog):
     ])
     parsed = yaml.safe_load(output)
     assert parsed == {"x": [{"changed-files": [{"any-glob-to-any-file": ["b"]}]}]}
-    assert any("Skipping file rule without `label`" in r.message for r in caplog.records)
+    assert any(
+        "Skipping file rule without `label`" in r.message for r in caplog.records
+    )
 
 
 def test_serialize_file_rules_skips_matcherless(caplog):
@@ -355,6 +356,5 @@ def test_augment_none_config():
     """A None config (caller opts out) preserves the bundled content."""
     bundled = "bundled: yes\n"
     assert (
-        _augment_labeller_content("labeller-file-based.yaml", bundled, None)
-        == bundled
+        _augment_labeller_content("labeller-file-based.yaml", bundled, None) == bundled
     )


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`7977aef7`](https://github.com/kdeldycke/repomatic/commit/7977aef74417b5195b8ce2961ac45a2b9c8888f3) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/7977aef74417b5195b8ce2961ac45a2b9c8888f3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/7977aef74417b5195b8ce2961ac45a2b9c8888f3/.github/workflows/autofix.yaml) |
| **Run** | [#4779.1](https://github.com/kdeldycke/repomatic/actions/runs/27599432557) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.2.dev0`