### PR TITLE
Bump minor version to `v6.27.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`6.26.1.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v6.26.0...main)
+## [`6.27.0.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v6.26.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "repomatic"
-version = "6.26.1.dev0"
+version = "6.27.0.dev0"
 description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 readme = "readme.md"
 keywords = [
@@ -123,7 +123,7 @@ repomatic = "repomatic.__main__:main"
 [project.urls]
 "Changelog" = "https://github.com/kdeldycke/repomatic/blob/main/changelog.md"
 "Documentation" = "https://kdeldycke.github.io/repomatic"
-"Download" = "https://github.com/kdeldycke/repomatic/releases/tag/v6.26.1.dev0"
+"Download" = "https://github.com/kdeldycke/repomatic/releases/tag/v6.27.0.dev0"
 "Funding" = "https://github.com/sponsors/kdeldycke"
 "Homepage" = "https://github.com/kdeldycke/repomatic"
 "Issues" = "https://github.com/kdeldycke/repomatic/issues"
@@ -207,7 +207,7 @@ copyright = "Kevin Deldycke <kevin@deldycke.com> and contributors. Distributed u
 file-description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 # Numeric only: Nuitka rejects PEP 440 .devN suffixes. Kept in sync with the
 # package version by the dedicated [tool.bumpversion] rule that strips the suffix.
-file-version = "6.26.1"
+file-version = "6.27.0"
 include-data-dir = [
   "repomatic/data/awesome_template=repomatic/data/awesome_template",
 ]
@@ -225,7 +225,7 @@ include-package-data = [ "click_extra" ]
 linux-icon = "docs/assets/icon.png"
 macos-app-icon = "docs/assets/icon.icns"
 product-name = "Repomatic"
-product-version = "6.26.1"
+product-version = "6.27.0"
 windows-icon-from-ico = "docs/assets/icon.ico"
 
 [tool.ruff]
@@ -309,7 +309,7 @@ run.source = [ "repomatic" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "6.26.1.dev0"
+current_version = "6.27.0.dev0"
 allow_dirty = true
 ignore_missing_files = true
 # Parse versions with an optional .devN suffix (PEP 440).

--- a/repomatic/__init__.py
+++ b/repomatic/__init__.py
@@ -17,5 +17,5 @@
 
 from __future__ import annotations
 
-__version__ = "6.26.1.dev0"
+__version__ = "6.27.0.dev0"
 __git_tag_sha__ = ""

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "repomatic"
-version = "6.26.1.dev0"
+version = "6.27.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

### To bump version to `v6.27.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e3f08cc9`](https://github.com/kdeldycke/repomatic/commit/e3f08cc9fff52f8f31930ac9434d8f1f7e29dd50) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/repomatic/blob/e3f08cc9fff52f8f31930ac9434d8f1f7e29dd50/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/e3f08cc9fff52f8f31930ac9434d8f1f7e29dd50/.github/workflows/changelog.yaml) |
| **Run** | [#4299.1](https://github.com/kdeldycke/repomatic/actions/runs/27713452771) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.27.0.dev0`