### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,7 @@ exclude-newer = "1 week"
 # pinned to git main (no PyPI release to freeze), so it keeps a permanent
 # "0 day" span. click-extra is held at 7.19.0 (manpages `--output-dir` flag);
 # tomlrt is held at 1.8.2.
-exclude-newer-package = { click-extra = "2026-06-14T00:00:00Z", repomatic = "0 day", tomlrt = "2026-06-16T00:00:00Z" }
+exclude-newer-package = { repomatic = "0 day", tomlrt = "2026-06-16T00:00:00Z" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,9 +11,8 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-click-extra = "2026-06-14T00:00:00Z"
-repomatic = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 tomlrt = "2026-06-16T00:00:00Z"
+repomatic = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [[package]]
 name = "accessible-pygments"
@@ -1652,14 +1651,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.10.5"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", marker = "python_full_version >= '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/88/f4698f838b8cc030f3df73cf529f96d7c9e6dd3e3ff40968b7fe4d86c748/sphinx_autodoc_typehints-3.10.5.tar.gz", hash = "sha256:a54dfab95a6b5e8601543d25474497e98ed59268ac0ab01b3daba9817cf9707e", size = 79721, upload-time = "2026-06-03T15:30:28.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ac/99f66f906b15718687525fdf3601ca0b50d19c5e88d57cd4275a89355926/sphinx_autodoc_typehints-3.11.0.tar.gz", hash = "sha256:0112b322e2ebd993c0561af3c9e4615481b42dec199d665d6bacc875f3371e96", size = 82518, upload-time = "2026-06-11T18:48:34.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/9a/98ba24ca28b4a4afbb5066805838c7e1149b8de1e6f5e02774e0f39f13db/sphinx_autodoc_typehints-3.10.5-py3-none-any.whl", hash = "sha256:7155748080735731c892d09b5128bc4e5303795691ca8515ccf333b1efd8d964", size = 40433, upload-time = "2026-06-03T15:30:26.892Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/55/7aaa2439e77cff66a6f348bb2d9894abf2b7b153595a5b974c5c277e9145/sphinx_autodoc_typehints-3.11.0-py3-none-any.whl", hash = "sha256:4ab73fe735c33168be3f34818034581155416e8e248d32ea1b604e90bea75223", size = 41610, upload-time = "2026-06-11T18:48:33.056Z" },
 ]
 
 [[package]]
@@ -1860,11 +1859,11 @@ wheels = [
 
 [[package]]
 name = "types-boltons"
-version = "25.0.0.20260518"
+version = "25.0.0.20260612"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/08/14/0bb319ee28c0b98042b16029877defe2378d2a82d44f28bee60684647d07/types_boltons-25.0.0.20260518.tar.gz", hash = "sha256:32cb6f76a7b795c89a1007b47e5cbf46e1d165c053df5b15bc2c6a508bb84795", size = 21876, upload-time = "2026-05-18T06:03:04.737Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/20/0f1d798ee2a11e59e228e8fea0947042bd80123b00fb4fd44673fb51e7db/types_boltons-25.0.0.20260612.tar.gz", hash = "sha256:85c2c90d17cdabe049037f1614af86bc858b214a5a16cc871230777e7cec39c9", size = 22004, upload-time = "2026-06-12T06:22:30.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/57/32c268c4d805c20c56ea826b3f50a349004039a48b7feb116715e2049b82/types_boltons-25.0.0.20260518-py3-none-any.whl", hash = "sha256:f1309216d8956c4e7b2ddf049c07d15c3dc5455bce79659815c1958d187fec10", size = 28295, upload-time = "2026-05-18T06:03:03.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/31/b8a58cffa7af1ebf6f9116168fcb129b175556794b815176d7a9118bf801/types_boltons-25.0.0.20260612-py3-none-any.whl", hash = "sha256:4ed2f2f3eca268c9b9a1ff4c4bc6c82cc460194d3c0ba6a9113316243f58feca", size = 28378, upload-time = "2026-06-12T06:22:29.816Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-12`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.10.5` → `3.11.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.5...3.11.0) | 2026-06-11 |
| [types-boltons](https://pypi.org/project/types-boltons/) | [`25.0.0.20260518` → `25.0.0.20260612`](https://github.com/python/typeshed/compare/v25.0.0.20260518...v25.0.0.20260612) | 2026-06-12 |

### Release notes

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.10.6`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.6)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(docstring): keep types on params with a trailing underscore by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/714
* ♻️ refactor(tests): fold per-issue test files into topical ones by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/715
* 🐛 fix(resolver): survive PEP 649 lazy annotation evaluation errors by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/713


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.5...3.10.6

#### [`3.11.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.11.0)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* ✨ feat(resolver): type C data descriptors from stub files by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/716


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.6...3.11.0

</details>

<details>
<summary><code>types-boltons</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/boltons.md)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`7220315e`](https://github.com/kdeldycke/repomatic/commit/7220315ec5e30a2e88ada7bb98efaf391857b615) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/7220315ec5e30a2e88ada7bb98efaf391857b615/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/7220315ec5e30a2e88ada7bb98efaf391857b615/.github/workflows/autofix.yaml) |
| **Run** | [#4816.1](https://github.com/kdeldycke/repomatic/actions/runs/27827966439) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.27.1.dev0`