### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,7 @@ exclude-newer = "1 week"
 # pinned to git main (no PyPI release to freeze), so it keeps a permanent
 # "0 day" span. tomlrt is held at 1.8.2. click-extra now tracks git main via
 # [tool.uv.sources], so the index cooldown does not apply to it.
-exclude-newer-package = { repomatic = "0 day", tomlrt = "2026-06-16T00:00:00Z" }
+exclude-newer-package = { repomatic = "0 day" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,6 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-tomlrt = "2026-06-16T00:00:00Z"
 repomatic = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [[package]]
@@ -399,14 +398,13 @@ wheels = [
 [[package]]
 name = "click-extra"
 version = "8.0.0.dev0"
-source = { git = "https://github.com/kdeldycke/click-extra?branch=main#43da2e3a089a8c95580288445f024c8bf2129c55" }
+source = { git = "https://github.com/kdeldycke/click-extra?branch=main#a13fca0a412a39f89c7212d69d73c3ceb620aa84" }
 dependencies = [
     { name = "boltons" },
     { name = "click" },
     { name = "cloup" },
     { name = "deepmerge" },
     { name = "extra-platforms" },
-    { name = "requests" },
     { name = "tabulate", extra = ["widechars"] },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
@@ -1326,7 +1324,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1337,9 +1335,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]
@@ -1563,10 +1561,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version >= '3.14'" },
+    { name = "charset-normalizer", marker = "python_full_version >= '3.14'" },
+    { name = "idna", marker = "python_full_version >= '3.14'" },
+    { name = "urllib3", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-15`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [pytest](https://pypi.org/project/pytest/) | [`9.0.3` → `9.1.0`](https://github.com/pytest-dev/pytest/compare/9.0.3...9.1.0) | 2026-06-13 |

### Release notes

<details>
<summary><code>pytest</code></summary>

#### [`9.1.0`](https://github.com/pytest-dev/pytest/releases/tag/9.1.0)

# pytest 9.1.0 (2026-06-13)

## Removals and backward incompatible breaking changes

- [\#​14533](https://redirect.github.com/pytest-dev/pytest/issues/14533): When using `--doctest-modules`, autouse fixtures with `module`, `package` or `session` scope that are defined inline in Python test modules (not plugins or conftests) will now possibly execute twice.

  If this is undesirable, move the fixture definition to a `conftest.py` file if possible.

  Technical explanation for those interested:
  When using <span class="title-ref">--doctest-modules</span>, pytest possibly collects Python modules twice, once as `pytest.Module` and once as a `DoctestModule` (depending on the configuration).
  Due to improvements in pytest's fixture implementation, if e.g. the `DoctestModule` collects a fixture, it is now visible to it only, and not to the `Module`.
  This means that both need to register the fixtures independently.

## Deprecations (removal in next major release)

- [\#​10819](https://redirect.github.com/pytest-dev/pytest/issues/10819): Added a deprecation warning for class-scoped fixtures defined as instance methods (without `@classmethod`). Such fixtures set attributes on a different instance than the test methods use, leading to unexpected behavior. Use `@classmethod` decorator instead -- by `yastcher`.

  See `10819` and `14011`.

- [\#​12882](https://redirect.github.com/pytest-dev/pytest/issues/12882): Calling `request.getfixturevalue() <pytest.FixtureRequest.getfixturevalue>` during teardown to request a fixture that was not already requested is now deprecated and will become an error in pytest 10.

  See `dynamic-fixture-request-during-teardown` for details.

... [Full release notes](https://github.com/pytest-dev/pytest/releases/tag/9.1.0)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`854ddeb3`](https://github.com/kdeldycke/repomatic/commit/854ddeb3d8d91536f8176379ba9b683ddaf1228c) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/854ddeb3d8d91536f8176379ba9b683ddaf1228c/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/854ddeb3d8d91536f8176379ba9b683ddaf1228c/.github/workflows/autofix.yaml) |
| **Run** | [#4843.1](https://github.com/kdeldycke/repomatic/actions/runs/27940551103) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.29.0.dev0`