### PR TITLE
Format Python

### DIFF
--- a/repomatic/metadata.py
+++ b/repomatic/metadata.py
@@ -2308,9 +2308,11 @@ class Metadata:
         # the os axis); skip it when that runner was removed.
         for version, keep_os in sorted(SINGLE_RUNNER_PYTHON_VERSIONS.items()):
             if keep_os not in removed_os:
-                matrix.add_includes(
-                    {"os": keep_os, "python-version": version, "state": "stable"}
-                )
+                matrix.add_includes({
+                    "os": keep_os,
+                    "python-version": version,
+                    "state": "stable",
+                })
         self._apply_test_matrix_config(matrix, full=True)
         return matrix
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`49197412`](https://github.com/kdeldycke/repomatic/commit/491974126f625fcfb17b2d8b681e9f5d785035d7) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/491974126f625fcfb17b2d8b681e9f5d785035d7/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/491974126f625fcfb17b2d8b681e9f5d785035d7/.github/workflows/autofix.yaml) |
| **Run** | [#4844.1](https://github.com/kdeldycke/repomatic/actions/runs/27943798929) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.29.0.dev0`