### PR TITLE
Format Python

### DIFF
--- a/repomatic/cli.py
+++ b/repomatic/cli.py
@@ -2685,7 +2685,8 @@ def audit(
         )
         for v in vulns
     ]
-    ctx.print_table(rows, _table_headers(AUDIT_HEADER_DEFS))  # type: ignore[attr-defined]
+    # type: ignore[attr-defined]
+    ctx.print_table(rows, _table_headers(AUDIT_HEADER_DEFS))
 
     if output:
         markdown = format_vulnerability_table(vulns)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -55,9 +55,11 @@ def _private_click_extra_imports(tree: ast.Module) -> list[str]:
                 continue
             if any(part.startswith("_") for part in parts[1:]):
                 violations.append(f"from {node.module} import ...")
-            for alias in node.names:
-                if alias.name.startswith("_"):
-                    violations.append(f"from {node.module} import {alias.name}")
+            violations.extend(
+                f"from {node.module} import {alias.name}"
+                for alias in node.names
+                if alias.name.startswith("_")
+            )
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 parts = alias.name.split(".")


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`02612c09`](https://github.com/kdeldycke/repomatic/commit/02612c09e3722d0fb4c3231b929c51b8b5a77725) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/02612c09e3722d0fb4c3231b929c51b8b5a77725/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/02612c09e3722d0fb4c3231b929c51b8b5a77725/.github/workflows/autofix.yaml) |
| **Run** | [#4854.1](https://github.com/kdeldycke/repomatic/actions/runs/27950999108) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.29.0.dev0`