### PR TITLE
Bump minor version to `v6.30.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`6.29.1.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v6.29.0...main)
+## [`6.30.0.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v6.29.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "repomatic"
-version = "6.29.1.dev0"
+version = "6.30.0.dev0"
 description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 readme = "readme.md"
 keywords = [
@@ -120,7 +120,7 @@ dependencies = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/repomatic/blob/main/changelog.md"
 urls.Documentation = "https://kdeldycke.github.io/repomatic"
-urls.Download = "https://github.com/kdeldycke/repomatic/releases/tag/v6.29.1.dev0"
+urls.Download = "https://github.com/kdeldycke/repomatic/releases/tag/v6.30.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/repomatic"
 urls.Issues = "https://github.com/kdeldycke/repomatic/issues"
@@ -214,7 +214,7 @@ copyright = "Kevin Deldycke <kevin@deldycke.com> and contributors. Distributed u
 file-description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 # Numeric only: Nuitka rejects PEP 440 .devN suffixes. Kept in sync with the
 # package version by the dedicated [tool.bumpversion] rule that strips the suffix.
-file-version = "6.29.1"
+file-version = "6.30.0"
 include-data-dir = [
   "repomatic/data/awesome_template=repomatic/data/awesome_template",
 ]
@@ -232,7 +232,7 @@ include-package-data = [ "click_extra" ]
 linux-icon = "docs/assets/icon.png"
 macos-app-icon = "docs/assets/icon.icns"
 product-name = "Repomatic"
-product-version = "6.29.1"
+product-version = "6.30.0"
 windows-icon-from-ico = "docs/assets/icon.ico"
 
 [tool.ruff]
@@ -335,7 +335,7 @@ run.source = [ "repomatic" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "6.29.1.dev0"
+current_version = "6.30.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/repomatic/__init__.py
+++ b/repomatic/__init__.py
@@ -17,5 +17,5 @@
 
 from __future__ import annotations
 
-__version__ = "6.29.1.dev0"
+__version__ = "6.30.0.dev0"
 __git_tag_sha__ = ""

--- a/uv.lock
+++ b/uv.lock
@@ -1476,7 +1476,7 @@ wheels = [
 
 [[package]]
 name = "repomatic"
-version = "6.29.1.dev0"
+version = "6.30.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

### To bump version to `v6.30.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`97c73cbb`](https://github.com/kdeldycke/repomatic/commit/97c73cbbc3db499fbaaea5a5b815b71995e11a0a) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/repomatic/blob/97c73cbbc3db499fbaaea5a5b815b71995e11a0a/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/97c73cbbc3db499fbaaea5a5b815b71995e11a0a/.github/workflows/changelog.yaml) |
| **Run** | [#4368.1](https://github.com/kdeldycke/repomatic/actions/runs/28094773335) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.30.0.dev0`