### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "8.1.0"
+version = "8.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -411,9 +411,9 @@ dependencies = [
     { name = "wcmatch" },
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/8d/b8bb7f8d6bbe0110022f26d412d1c3e035987676af68e22cf9acc941ad76/click_extra-8.1.0.tar.gz", hash = "sha256:34496f0b94b95e07c0be76d21f655a222522a9deb906c67886d89ad2f33bda60", size = 306075, upload-time = "2026-06-24T10:37:32.175Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ee/61eb8cadbf58b3570bab603106076e46466e890f7aba19ac4a420b27511f/click_extra-8.1.1.tar.gz", hash = "sha256:d9fa8de46b5fac91c7cbb0be5e1a788f04845d01a5580f210f90761f16be7cd6", size = 306766, upload-time = "2026-06-24T15:35:08.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/86/1c97208a56d3d4a87628f88167f1684a80f79b07de7a7aa60431d5a43582/click_extra-8.1.0-py3-none-any.whl", hash = "sha256:b23cb2b197da0b1ffb2de1b2fa589c46be4881aa55b5b6eae041139295ff5800", size = 332431, upload-time = "2026-06-24T10:37:30.522Z" },
+    { url = "https://files.pythonhosted.org/packages/73/46/406186bcf0963d0fcd9e89c0e00f4dcb761ad5b1ec91fbca7fd4f1909677/click_extra-8.1.1-py3-none-any.whl", hash = "sha256:73b51c2247177a2830573420d90f9bdc07dbcd2d226e34d098a7f4cd53972180", size = 333109, upload-time = "2026-06-24T15:35:07.107Z" },
 ]
 
 [package.optional-dependencies]
@@ -1847,14 +1847,14 @@ wheels = [
 
 [[package]]
 name = "tomlrt"
-version = "1.8.2"
+version = "1.8.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/03/d3635f3a1f3983532552b5655fd93be854a92216a33b4c94c72407dc4621/tomlrt-1.8.2.tar.gz", hash = "sha256:df51f6c88353ae074a8d0656b56192baf19ef712a205764605a1fcc5558dc407", size = 318565, upload-time = "2026-06-14T18:41:29.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/0e/3d2ea889b18c5c78f8d5c9a8ae6f4d16fe2317ccfa95265a08bb8b3cac48/tomlrt-1.8.3.tar.gz", hash = "sha256:1991103d65f43e047854599e46c7c136696d74ce7fa15485242f9b9f59104433", size = 322934, upload-time = "2026-06-17T20:53:44.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/42/b3dff14c80d9169c8070a534e5d347566180cd88f6f052b4b9e573b898d0/tomlrt-1.8.2-py3-none-any.whl", hash = "sha256:3fa58085d07cacdffd6104faca50a66e5cbb7693c0a4b6109b3473d16ff0787c", size = 133241, upload-time = "2026-06-14T18:41:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/05/fde2f039c204b686b6053261870d98c08f2d9a095d02e94ea262977c7a4e/tomlrt-1.8.3-py3-none-any.whl", hash = "sha256:5c869c825a19df16ced788d92cc5eb952385d2e3b0874ce82db4fb01ae2f690a", size = 135285, upload-time = "2026-06-17T20:53:42.829Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-18`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | [`8.1.0` → `8.1.1`](https://github.com/kdeldycke/click-extra/compare/v8.1.0...v8.1.1) | 2026-06-24 |
| [tomlrt](https://pypi.org/project/tomlrt/) | [`1.8.2` → `1.8.3`](https://github.com/dimbleby/tomlrt/compare/v1.8.2...v1.8.3) | 2026-06-17 |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.1.1`](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.1)

- Fix `multiple` and variadic (`nargs=-1`) options typed with `EnumChoice`: their tuple default was stringified as a whole (`str((MyEnum.FOO,))`) instead of per member, so the default tripped Click's `Value must be an iterable` check when the option was left unset.
- Fix `decorator_factory` leaking options across uses of a pre-instantiated decorator: when `command()` is stored (e.g. in a pytest parametrize list) and reused, Click mutated the shared `params` list by extending it with each decorated function's options, adding duplicates on every reuse. The fix re-evaluates `params_func()` fresh on each application.

**Full changelog**: [`v8.1.0...v8.1.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.1.0...v8.1.1)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.1.1-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.1/click-extra-8.1.1-linux-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/eaefe04f7ac047957c295c8b4372a34b8a8ae77815a61c884526946dd8a31be3) |
| [`click-extra-8.1.1-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.1/click-extra-8.1.1-linux-x64.bin) | 0 / 62 | [View scan](https://www.virustotal.com/gui/file/b97c426b0eec2a841e4b13a29afa11aff0e27f4944b108a0ac9c9e059768a708) |
| [`click-extra-8.1.1-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.1/click-extra-8.1.1-macos-arm64.bin) | *pending* | [View scan](https://www.virustotal.com/gui/file/4115aef54ed12a52320b0c78cd7c80678b98438b5b9b4fb208ebcc32a828718a) |
| [`click-extra-8.1.1-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.1/click-extra-8.1.1-macos-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/0dd21cf61119135ad45f88af682056be6603b03fe492c751ae82a0b56be5a022) |

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.1)

</details>

<details>
<summary><code>tomlrt</code></summary>

[Changelog](https://redirect.github.com/dimbleby/tomlrt/blob/main/CHANGELOG.md)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e700c6ba`](https://github.com/kdeldycke/repomatic/commit/e700c6bad88ce0d05d83a5415f38062be60b2756) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/e700c6bad88ce0d05d83a5415f38062be60b2756/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/e700c6bad88ce0d05d83a5415f38062be60b2756/.github/workflows/autofix.yaml) |
| **Run** | [#4879.1](https://github.com/kdeldycke/repomatic/actions/runs/28157896407) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.30.1.dev0`