### PR TITLE
Format Python

### DIFF
--- a/repomatic/github/releases.py
+++ b/repomatic/github/releases.py
@@ -46,9 +46,7 @@ GITHUB_API_TAG_REF_URL = (
 )
 """GitHub API URL for resolving a tag name to its git object."""
 
-GITHUB_API_TAG_OBJECT_URL = (
-    "https://api.github.com/repos/{owner}/{repo}/git/tags/{sha}"
-)
+GITHUB_API_TAG_OBJECT_URL = "https://api.github.com/repos/{owner}/{repo}/git/tags/{sha}"
 """GitHub API URL for dereferencing an annotated tag object to its commit."""
 
 GITHUB_API_RELEASE_BY_TAG_URL = (

--- a/repomatic/version_sync.py
+++ b/repomatic/version_sync.py
@@ -393,10 +393,7 @@ def apply_action_pins(
         if new_sha == match.group("sha"):
             return match.group(0)
         changes.append((slug, match.group("ref"), new_ref))
-        return (
-            f"{match.group('prefix')}{slug}@{new_sha}"
-            f"{match.group('gap')}{new_ref}"
-        )
+        return f"{match.group('prefix')}{slug}@{new_sha}{match.group('gap')}{new_ref}"
 
     return ACTION_PIN_RE.sub(replace, content), changes
 
@@ -435,9 +432,7 @@ def apply_workflow_literals(
             if not new_version or new_version == old_version:
                 return match.group(0)
             changes.append((package, old_version, new_version))
-            return match.group(0).replace(
-                f"{sep}{old_version}", f"{sep}{new_version}"
-            )
+            return match.group(0).replace(f"{sep}{old_version}", f"{sep}{new_version}")
 
         return inner
 

--- a/tests/test_github_releases.py
+++ b/tests/test_github_releases.py
@@ -242,9 +242,9 @@ def test_fetch_github_release_notes_filters_range_and_sorts():
         "v1.3.0": GitHubRelease(date="2026-04-01", body="too new"),  # > new: excluded.
     }
     with patch("repomatic.github.releases.get_release_tags", return_value=fake):
-        notes = fetch_github_release_notes(
-            [("checkout", "https://github.com/actions/checkout", "1.0.0", "1.2.0", None)]
-        )
+        notes = fetch_github_release_notes([
+            ("checkout", "https://github.com/actions/checkout", "1.0.0", "1.2.0", None)
+        ])
     repo_url, versions = notes["checkout"]
     assert repo_url == "https://github.com/actions/checkout"
     # Only the half-open range (1.0.0, 1.2.0], oldest first.
@@ -254,9 +254,9 @@ def test_fetch_github_release_notes_filters_range_and_sorts():
 def test_fetch_github_release_notes_skips_empty_bodies():
     fake = {"v2.0.0": GitHubRelease(date="2026-02-01", body="")}
     with patch("repomatic.github.releases.get_release_tags", return_value=fake):
-        notes = fetch_github_release_notes(
-            [("x", "https://github.com/o/x", "1.0.0", "2.0.0", None)]
-        )
+        notes = fetch_github_release_notes([
+            ("x", "https://github.com/o/x", "1.0.0", "2.0.0", None)
+        ])
     assert notes == {}
 
 
@@ -265,9 +265,9 @@ def test_fetch_github_release_notes_graceful_when_unavailable():
         "repomatic.github.releases.get_release_tags",
         side_effect=GitHubReleasesUnavailable("boom"),
     ):
-        notes = fetch_github_release_notes(
-            [("x", "https://github.com/o/x", "1.0.0", "2.0.0", None)]
-        )
+        notes = fetch_github_release_notes([
+            ("x", "https://github.com/o/x", "1.0.0", "2.0.0", None)
+        ])
     assert notes == {}
 
 

--- a/tests/test_lint_repo.py
+++ b/tests/test_lint_repo.py
@@ -592,9 +592,7 @@ def test_pat_check_annotates_with_github_status_incident():
 def test_pat_stale_statuses_permission_present():
     """Warn when a 422 proves the token still grants Commit statuses."""
     with patch("repomatic.lint_repo.run_gh_command") as mock_gh:
-        mock_gh.side_effect = RuntimeError(
-            "No commit found for SHA: 000... (HTTP 422)"
-        )
+        mock_gh.side_effect = RuntimeError("No commit found for SHA: 000... (HTTP 422)")
         warning, _msg = check_pat_stale_statuses_permission("owner/repo")
         assert warning is not None
         assert "Commit statuses" in warning

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -289,8 +289,11 @@ def test_build_held_back_formats_released_and_eligible():
 
 def test_format_held_back_table_is_parametrized_by_subject_and_links():
     """One renderer serves uv (PyPI) and the version-sync updaters (GitHub/npm)."""
-    rows = [HeldBackPackage("actions/checkout", "6.0.3",
-                            "7.0.0", "2026-06-26", "2026-07-04")]
+    rows = [
+        HeldBackPackage(
+            "actions/checkout", "6.0.3", "7.0.0", "2026-06-26", "2026-07-04"
+        )
+    ]
     table = format_held_back_table(
         rows,
         "CUSTOM COOLDOWN NOTE",


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`66e45541`](https://github.com/kdeldycke/repomatic/commit/66e4554110e7628f95889241cc7b55662ce1123a) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/66e4554110e7628f95889241cc7b55662ce1123a/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/66e4554110e7628f95889241cc7b55662ce1123a/.github/workflows/autofix.yaml) |
| **Run** | [#4910.1](https://github.com/kdeldycke/repomatic/actions/runs/28325196776) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.0.dev0`