### PR TITLE
Typo

### DIFF
--- a/repomatic/version_sync.py
+++ b/repomatic/version_sync.py
@@ -336,7 +336,7 @@ def npm_candidates(package: str) -> list[Candidate]:
 def is_newer(new: str, old: str) -> bool:
     """Return `True` when *new* is a strictly higher version than *old*.
 
-    Unparseable versions compare as not-newer, so a malformed candidate never
+    Unparsable versions compare as not-newer, so a malformed candidate never
     triggers a bump.
     """
     try:

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -112,7 +112,7 @@ def test_select_latest_none_when_all_too_new():
     assert vs.select_latest(candidates, timedelta(days=8), TODAY) is None
 
 
-def test_select_latest_skips_unparseable_versions_and_dates():
+def test_select_latest_skips_unparsable_versions_and_dates():
     candidates = [
         vs.Candidate("not-a-version", "2026-01-01", "x"),
         vs.Candidate("1.0.0", "not-a-date", "v1.0.0"),
@@ -168,7 +168,7 @@ def test_select_held_back_skips_prereleases_by_default():
     assert allowed is not None and allowed.version == "2.0.0rc1"
 
 
-def test_select_held_back_skips_unparseable():
+def test_select_held_back_skips_unparsable():
     candidates = [
         vs.Candidate("bad", "2026-06-26", "x"),
         vs.Candidate("1.2.0", "not-a-date", "v1.2.0"),


### PR DESCRIPTION
### Description

Fixes typos detected by [typos](https://github.com/crate-ci/typos). See the [`fix-typos` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Manage false positives and customize spell-checking rules via [`[tool.typos]`](https://github.com/crate-ci/typos/blob/master/docs/reference.md) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`66e45541`](https://github.com/kdeldycke/repomatic/commit/66e4554110e7628f95889241cc7b55662ce1123a) |
| **Job** | [`fix-typos`](https://github.com/kdeldycke/repomatic/blob/66e4554110e7628f95889241cc7b55662ce1123a/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/66e4554110e7628f95889241cc7b55662ce1123a/.github/workflows/autofix.yaml) |
| **Run** | [#4910.1](https://github.com/kdeldycke/repomatic/actions/runs/28325196776) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.0.dev0`