### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_runner.py
+++ b/repomatic/tool_runner.py
@@ -962,7 +962,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "bump-my-version": ToolSpec(
         name="bump-my-version",
-        version="1.2.7",
+        version="1.4.1",
         reads_pyproject=True,
         source_url="https://github.com/callowayproject/bump-my-version",
         config_docs_url="https://callowayproject.github.io/bump-my-version/reference/configuration/",
@@ -1131,7 +1131,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "mypy": ToolSpec(
         name="mypy",
-        version="1.19.1",
+        version="2.1.0",
         source_url="https://github.com/python/mypy",
         config_docs_url="https://mypy.readthedocs.io/en/stable/config_file.html",
         cli_docs_url="https://mypy.readthedocs.io/en/stable/command_line.html",
@@ -1148,7 +1148,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "nuitka": ToolSpec(
         name="nuitka",
         display_name="Nuitka",
-        version="4.1",
+        version="4.1.3",
         package="nuitka[onefile]",
         source_url="https://github.com/Nuitka/Nuitka",
         config_docs_url="https://nuitka.net/doc/user-manual.html",
@@ -1172,7 +1172,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "ruff": ToolSpec(
         name="ruff",
         display_name="Ruff",
-        version="0.15.5",
+        version="0.15.18",
         source_url="https://github.com/astral-sh/ruff",
         config_docs_url="https://docs.astral.sh/ruff/configuration/",
         cli_docs_url="https://docs.astral.sh/ruff/configuration/#command-line-interface",
@@ -1277,7 +1277,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "zizmor": ToolSpec(
         name="zizmor",
-        version="1.23.0",
+        version="1.26.1",
         source_url="https://github.com/zizmorcore/zizmor",
         config_docs_url="https://docs.zizmor.sh/configuration/",
         cli_docs_url="https://docs.zizmor.sh/usage/",


### PR DESCRIPTION
### Description

Bumps the tools in the [`repomatic run`](https://kdeldycke.github.io/repomatic/tool-runner.html) registry to their latest releases that have cleared the stabilization cooldown (GitHub releases for binary tools, PyPI otherwise), refreshing binary checksums in the same pass. See the [`sync-tool-versions` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-21` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [bump-my-version](https://github.com/callowayproject/bump-my-version) | `1.2.7` → `1.4.1` | 2026-06-18 (a week ago) |
| [mypy](https://github.com/python/mypy) | `1.19.1` → `2.1.0` | 2026-05-11 (2 months ago) |
| [nuitka](https://github.com/Nuitka/Nuitka) | `4.1` → `4.1.3` | 2026-06-21 (a week ago) |
| [ruff](https://github.com/astral-sh/ruff) | `0.15.5` → `0.15.18` | 2026-06-18 (a week ago) |
| [zizmor](https://github.com/zizmorcore/zizmor) | `1.23.0` → `1.26.1` | 2026-06-21 (a week ago) |

### Release notes

<details>
<summary><code>bump-my-version</code></summary>

#### [`1.3.0`](https://github.com/callowayproject/bump-my-version/releases/tag/1.3.0)

[Compare the full difference.](https://redirect.github.com/callowayproject/bump-my-version/compare/1.2.7...1.3.0)

### Fixes

- Refactor hook script execution to handle platform-specific argument parsing; update typing imports. [a46b63d](https://redirect.github.com/callowayproject/bump-my-version/commit/a46b63dec2559c23ce2bee134f295d5b3e3439d5)
    
### New

- Add `allow_shell_hooks` option for safe hook execution; improve shell syntax handling. [036ee1a](https://redirect.github.com/callowayproject/bump-my-version/commit/036ee1a909aeea02eb8e4b144f856fb6d70444e9)
    
  - Introduce `allow_shell_hooks` configuration to control shell metacharacters in hooks.
  - Change default behavior to disallow shell syntax (`shell=False`) unless explicitly enabled.
  - Add regex detection for shell syntax and migrate affected hooks.
  - Update tests and fixtures to cover new functionality.
  - Enhance documentation with migration guidance and best practices.
### Other

- Standardize formatting, spacing, and indentation across documentation and templates for consistency. [1b9eb42](https://redirect.github.com/callowayproject/bump-my-version/commit/1b9eb429b1cf9c458aea70c1eea6507c59089827)
    
- Modularize CLI commands into individual files: `bump`, `replace`, `show`, `show-bump`, and `sample-config`; add corresponding tests and shared options file. [c35c431](https://redirect.github.com/callowayproject/bump-my-version/commit/c35c4315407e775a714a971281ddcbda8a334ecc)
    
- Make `--regex` option nullable; add tests for precedence between CLI flags and config. [c78bbef](https://redirect.github.com/callowayproject/bump-my-version/commit/c78bbefdac3d0ee21acf2864c81c0cf0ffa8b27c)
    
### Updates

- Update pre-commit, improve `is_subpath` logic, and enhance documentation. [919c66b](https://redirect.github.com/callowayproject/bump-my-version/commit/919c66b6c58095908dfd9ccdabab1cb367260df5)
    
  - Update `ruff-pre-commit` to v0.15.1 in pre-commit config.

... [Full release notes](https://github.com/callowayproject/bump-my-version/releases/tag/1.3.0)

#### [`1.4.0`](https://github.com/callowayproject/bump-my-version/releases/tag/1.4.0)

[Compare the full difference.](https://redirect.github.com/callowayproject/bump-my-version/compare/1.3.0...1.4.0)

### Fixes

- Fixed linting errors. [8196116](https://redirect.github.com/callowayproject/bump-my-version/commit/8196116eab9825b4f4589bd042386c804518f0a8)

### Other

- Bump codecov/codecov-action from 6 to 7 in the github-actions group. [430128e](https://redirect.github.com/callowayproject/bump-my-version/commit/430128e2cfc37fb6fa1a08e5eef47a53f9079ba6)

  Bumps the github-actions group with 1 update: [codecov/codecov-action](https://redirect.github.com/codecov/codecov-action).

  Updates `codecov/codecov-action` from 6 to 7

  - [Release notes](https://redirect.github.com/codecov/codecov-action/releases)
  - [Changelog](https://redirect.github.com/codecov/codecov-action/blob/main/CHANGELOG.md)
  - [Commits](https://redirect.github.com/codecov/codecov-action/compare/v6...v7)

  ______________________________________________________________________

  **updated-dependencies:** - dependency-name: codecov/codecov-action
  dependency-version: '7'
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: github-actions

  **signed-off-by:** dependabot[bot] <support@github.com>

- [pre-commit.ci] pre-commit autoupdate. [8124a90](https://redirect.github.com/callowayproject/bump-my-version/commit/8124a90de40f5de325ab5668a05da166f65f1144)

  **updates:** - [github.com/astral-sh/ruff-pre-commit: v0.15.15 → v0.15.17](https://redirect.github.com/astral-sh/ruff-pre-commit/compare/v0.15.15...v0.15.17)

- [pre-commit.ci] pre-commit autoupdate. [da390f0](https://redirect.github.com/callowayproject/bump-my-version/commit/da390f001284c88b488df6e35f5eb4840a1e6392)

  **updates:** - [github.com/astral-sh/ruff-pre-commit: v0.15.8 → v0.15.15](https://redirect.github.com/astral-sh/ruff-pre-commit/compare/v0.15.8...v0.15.15)

... [Full release notes](https://github.com/callowayproject/bump-my-version/releases/tag/1.4.0)

</details>

<details>
<summary><code>ruff</code></summary>

#### [`0.15.6`](https://github.com/astral-sh/ruff/releases/tag/0.15.6)

## Release Notes

Released on 2026-03-12.

### Preview features

- Add support for `lazy` import parsing ([#​23755](https://redirect.github.com/astral-sh/ruff/pull/23755))
- Add support for star-unpacking of comprehensions (PEP 798) ([#​23788](https://redirect.github.com/astral-sh/ruff/pull/23788))
- Reject semantic syntax errors for lazy imports ([#​23757](https://redirect.github.com/astral-sh/ruff/pull/23757))
- Drop a few rules from the preview default set ([#​23879](https://redirect.github.com/astral-sh/ruff/pull/23879))
- \[`airflow`\] Flag `Variable.get()` calls outside of task execution context (`AIR003`) ([#​23584](https://redirect.github.com/astral-sh/ruff/pull/23584))
- \[`airflow`\] Flag runtime-varying values in DAG/task constructor arguments (`AIR304`) ([#​23631](https://redirect.github.com/astral-sh/ruff/pull/23631))
- \[`flake8-bugbear`\] Implement `delattr-with-constant` (`B043`) ([#​23737](https://redirect.github.com/astral-sh/ruff/pull/23737))
- \[`flake8-tidy-imports`\] Add `TID254` to enforce lazy imports ([#​23777](https://redirect.github.com/astral-sh/ruff/pull/23777))
- \[`flake8-tidy-imports`\] Allow users to ban lazy imports with `TID254` ([#​23847](https://redirect.github.com/astral-sh/ruff/pull/23847))
- \[`isort`\] Retain `lazy` keyword when sorting imports ([#​23762](https://redirect.github.com/astral-sh/ruff/pull/23762))
- \[`pyupgrade`\] Add `from __future__ import annotations` automatically (`UP006`) ([#​23260](https://redirect.github.com/astral-sh/ruff/pull/23260))
- \[`refurb`\] Support `newline` parameter in `FURB101` for Python 3.13+ ([#​23754](https://redirect.github.com/astral-sh/ruff/pull/23754))
- \[`ruff`\] Add `os-path-commonprefix` (`RUF071`) ([#​23814](https://redirect.github.com/astral-sh/ruff/pull/23814))
- \[`ruff`\] Add unsafe fix for os-path-commonprefix (`RUF071`) ([#​23852](https://redirect.github.com/astral-sh/ruff/pull/23852))

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.6)

#### [`0.15.7`](https://github.com/astral-sh/ruff/releases/tag/0.15.7)

## Release Notes

Released on 2026-03-19.

### Preview features

- Display output severity in preview ([#​23845](https://redirect.github.com/astral-sh/ruff/pull/23845))
- Don't show `noqa` hover for non-Python documents ([#​24040](https://redirect.github.com/astral-sh/ruff/pull/24040))

### Rule changes

- \[`pycodestyle`\] Recognize `pyrefly:` as a pragma comment (`E501`) ([#​24019](https://redirect.github.com/astral-sh/ruff/pull/24019))

### Server

- Don't return code actions for non-Python documents ([#​23905](https://redirect.github.com/astral-sh/ruff/pull/23905))

### Documentation

- Add company AI policy to contributing guide ([#​24021](https://redirect.github.com/astral-sh/ruff/pull/24021))
- Document editor features for Markdown code formatting ([#​23924](https://redirect.github.com/astral-sh/ruff/pull/23924))
- \[`pylint`\] Improve phrasing (`PLC0208`) ([#​24033](https://redirect.github.com/astral-sh/ruff/pull/24033))

### Other changes

- Use PEP 639 license information ([#​19661](https://redirect.github.com/astral-sh/ruff/pull/19661))

### Contributors

- [@​tmimmanuel](https://redirect.github.com/tmimmanuel)
- [@​DimitriPapadopoulos](https://redirect.github.com/DimitriPapadopoulos)
- [@​amyreese](https://redirect.github.com/amyreese)
- [@​statxc](https://redirect.github.com/statxc)
- [@​dylwil3](https://redirect.github.com/dylwil3)
- [@​hunterhogan](https://redirect.github.com/hunterhogan)
- [@​renovate](https://redirect.github.com/renovate)

## Install ruff 0.15.7

### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/ruff/releases/download/0.15.7/ruff-installer.sh | sh
```

### Install prebuilt binaries via powershell script

```sh
powershell -ExecutionPolicy Bypass -c "irm https://releases.astral.sh/github/ruff/releases/download/0.15.7/ruff-installer.ps1 | iex"
```

## Download ruff 0.15.7

|  File  | Platform | Checksum |
|--------|----------|----------|

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.7)

#### [`0.15.8`](https://github.com/astral-sh/ruff/releases/tag/0.15.8)

## Release Notes

Released on 2026-03-26.

### Preview features

- \[`ruff`\] New rule `unnecessary-if` (`RUF050`) ([#​24114](https://redirect.github.com/astral-sh/ruff/pull/24114))
- \[`ruff`\] New rule `useless-finally` (`RUF072`) ([#​24165](https://redirect.github.com/astral-sh/ruff/pull/24165))
- \[`ruff`\] New rule `f-string-percent-format` (`RUF073`): warn when using `%` operator on an f-string ([#​24162](https://redirect.github.com/astral-sh/ruff/pull/24162))
- \[`pyflakes`\] Recognize `frozendict` as a builtin for Python 3.15+ ([#​24100](https://redirect.github.com/astral-sh/ruff/pull/24100))

### Bug fixes

- \[`flake8-async`\] Use fully-qualified `anyio.lowlevel` import in autofix (`ASYNC115`) ([#​24166](https://redirect.github.com/astral-sh/ruff/pull/24166))
- \[`flake8-bandit`\] Check tuple arguments for partial paths in `S607` ([#​24080](https://redirect.github.com/astral-sh/ruff/pull/24080))
- \[`pyflakes`\] Skip `undefined-name` (`F821`) for conditionally deleted variables ([#​24088](https://redirect.github.com/astral-sh/ruff/pull/24088))
- `E501`/`W505`/formatter: Exclude nested pragma comments from line width calculation ([#​24071](https://redirect.github.com/astral-sh/ruff/pull/24071))
- Fix `%foo?` parsing in IPython assignment expressions ([#​24152](https://redirect.github.com/astral-sh/ruff/pull/24152))
- `analyze graph`: resolve string imports that reference attributes, not just modules ([#​24058](https://redirect.github.com/astral-sh/ruff/pull/24058))

### Rule changes

- \[`eradicate`\] ignore `ty: ignore` comments in `ERA001` ([#​24192](https://redirect.github.com/astral-sh/ruff/pull/24192))
- \[`flake8-bandit`\] Treat `sys.executable` as trusted input in `S603` ([#​24106](https://redirect.github.com/astral-sh/ruff/pull/24106))
- \[`flake8-self`\] Recognize `Self` annotation and `self` assignment in `SLF001` ([#​24144](https://redirect.github.com/astral-sh/ruff/pull/24144))

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.8)

#### [`0.15.9`](https://github.com/astral-sh/ruff/releases/tag/0.15.9)

## Release Notes

Released on 2026-04-02.

### Preview features

- \[`pyflakes`\] Flag annotated variable redeclarations as `F811` in preview mode ([#​24244](https://redirect.github.com/astral-sh/ruff/pull/24244))
- \[`ruff`\] Allow dunder-named assignments in non-strict mode for `RUF067` ([#​24089](https://redirect.github.com/astral-sh/ruff/pull/24089))

### Bug fixes

- \[`flake8-errmsg`\] Avoid shadowing existing `msg` in fix for `EM101` ([#​24363](https://redirect.github.com/astral-sh/ruff/pull/24363))
- \[`flake8-simplify`\] Ignore pre-initialization references in `SIM113` ([#​24235](https://redirect.github.com/astral-sh/ruff/pull/24235))
- \[`pycodestyle`\] Fix `W391` fixes for consecutive empty notebook cells ([#​24236](https://redirect.github.com/astral-sh/ruff/pull/24236))
- \[`pyupgrade`\] Fix `UP008` nested class matching ([#​24273](https://redirect.github.com/astral-sh/ruff/pull/24273))
- \[`pyupgrade`\] Ignore strings with string-only escapes (`UP012`) ([#​16058](https://redirect.github.com/astral-sh/ruff/pull/16058))
- \[`ruff`\] `RUF072`: skip formfeeds on dedent ([#​24308](https://redirect.github.com/astral-sh/ruff/pull/24308))
- \[`ruff`\] Avoid re-using symbol in `RUF024` fix ([#​24316](https://redirect.github.com/astral-sh/ruff/pull/24316))
- \[`ruff`\] Parenthesize expression in `RUF050` fix ([#​24234](https://redirect.github.com/astral-sh/ruff/pull/24234))
- Disallow starred expressions as values of starred expressions ([#​24280](https://redirect.github.com/astral-sh/ruff/pull/24280))

### Rule changes

- \[`flake8-simplify`\] Suppress `SIM105` for `except*` before Python 3.12 ([#​23869](https://redirect.github.com/astral-sh/ruff/pull/23869))
- \[`pyflakes`\] Extend `F507` to flag `%`-format strings with zero placeholders ([#​24215](https://redirect.github.com/astral-sh/ruff/pull/24215))
- \[`pyupgrade`\] `UP018` should detect more unnecessarily wrapped literals (UP018) ([#​24093](https://redirect.github.com/astral-sh/ruff/pull/24093))

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.9)

#### [`0.15.10`](https://github.com/astral-sh/ruff/releases/tag/0.15.10)

## Release Notes

Released on 2026-04-09.

### Preview features

- \[`flake8-logging`\] Allow closures in except handlers (`LOG004`) ([#​24464](https://redirect.github.com/astral-sh/ruff/pull/24464))
- \[`flake8-self`\] Make `SLF` diagnostics robust to non-self-named variables ([#​24281](https://redirect.github.com/astral-sh/ruff/pull/24281))
- \[`flake8-simplify`\] Make the fix for `collapsible-if` safe in `preview` (`SIM102`) ([#​24371](https://redirect.github.com/astral-sh/ruff/pull/24371))

### Bug fixes

- Avoid emitting multi-line f-string elements before Python 3.12 ([#​24377](https://redirect.github.com/astral-sh/ruff/pull/24377))
- Avoid syntax error from `E502` fixes in f-strings and t-strings ([#​24410](https://redirect.github.com/astral-sh/ruff/pull/24410))
- Strip form feeds from indent passed to `dedent_to` ([#​24381](https://redirect.github.com/astral-sh/ruff/pull/24381))
- \[`pyupgrade`\] Fix panic caused by handling of octals (`UP012`) ([#​24390](https://redirect.github.com/astral-sh/ruff/pull/24390))
- Reject multi-line f-string elements before Python 3.12 ([#​24355](https://redirect.github.com/astral-sh/ruff/pull/24355))

### Rule changes

- \[`ruff`\] Treat f-string interpolation as potential side effect (`RUF019`) ([#​24426](https://redirect.github.com/astral-sh/ruff/pull/24426))

### Server

- Add support for custom file extensions ([#​24463](https://redirect.github.com/astral-sh/ruff/pull/24463))

### Documentation

- Document adding fixes in CONTRIBUTING.md ([#​24393](https://redirect.github.com/astral-sh/ruff/pull/24393))
- Fix JSON typo in settings example ([#​24517](https://redirect.github.com/astral-sh/ruff/pull/24517))

### Contributors

- [@​charliermarsh](https://redirect.github.com/charliermarsh)
- [@​dylwil3](https://redirect.github.com/dylwil3)
- [@​silverstein](https://redirect.github.com/silverstein)
- [@​anishgirianish](https://redirect.github.com/anishgirianish)
- [@​shizukushq](https://redirect.github.com/shizukushq)

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.10)

#### [`0.15.11`](https://github.com/astral-sh/ruff/releases/tag/0.15.11)

## Release Notes

Released on 2026-04-16.

### Preview features

- \[`ruff`\] Ignore `RUF029` when function is decorated with `asynccontextmanager` ([#​24642](https://redirect.github.com/astral-sh/ruff/pull/24642))
- \[`airflow`\] Implement `airflow-xcom-pull-in-template-string` (`AIR201`) ([#​23583](https://redirect.github.com/astral-sh/ruff/pull/23583))
- \[`flake8-bandit`\] Fix `S103` false positives and negatives in mask analysis ([#​24424](https://redirect.github.com/astral-sh/ruff/pull/24424))

### Bug fixes

- \[`flake8-async`\] Omit overridden methods for `ASYNC109` ([#​24648](https://redirect.github.com/astral-sh/ruff/pull/24648))

### Documentation

- \[`flake8-async`\] Add override mention to `ASYNC109` docs ([#​24666](https://redirect.github.com/astral-sh/ruff/pull/24666))
- Update Neovim config examples to use `vim.lsp.config` ([#​24577](https://redirect.github.com/astral-sh/ruff/pull/24577))

### Contributors

- [@​augustelalande](https://redirect.github.com/augustelalande)
- [@​anishgirianish](https://redirect.github.com/anishgirianish)
- [@​benberryallwood](https://redirect.github.com/benberryallwood)
- [@​charliermarsh](https://redirect.github.com/charliermarsh)
- [@​Dev-iL](https://redirect.github.com/Dev-iL)

## Install ruff 0.15.11

### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/ruff/releases/download/0.15.11/ruff-installer.sh | sh
```

### Install prebuilt binaries via powershell script

```sh
powershell -ExecutionPolicy Bypass -c "irm https://releases.astral.sh/github/ruff/releases/download/0.15.11/ruff-installer.ps1 | iex"
```

## Download ruff 0.15.11

|  File  | Platform | Checksum |
|--------|----------|----------|

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.11)

#### [`0.15.12`](https://github.com/astral-sh/ruff/releases/tag/0.15.12)

## Release Notes

Released on 2026-04-24.

### Preview features

- Implement `#ruff:file-ignore` file-level suppressions ([#​23599](https://redirect.github.com/astral-sh/ruff/pull/23599))
- Implement `#ruff:ignore` logical-line suppressions ([#​23404](https://redirect.github.com/astral-sh/ruff/pull/23404))
- Revert preview changes to displayed diagnostic severity in LSP ([#​24789](https://redirect.github.com/astral-sh/ruff/pull/24789))
- \[`airflow`\] Implement `task-branch-as-short-circuit` (`AIR004`) ([#​23579](https://redirect.github.com/astral-sh/ruff/pull/23579))
- \[`flake8-bugbear`\] Fix `break`/`continue` handling in `loop-iterator-mutation` (`B909`) ([#​24440](https://redirect.github.com/astral-sh/ruff/pull/24440))
- \[`pylint`\] Fix `PLC2701` for type parameter scopes ([#​24576](https://redirect.github.com/astral-sh/ruff/pull/24576))

### Rule changes

- \[`pandas-vet`\] Suggest `.array` as well in `PD011` ([#​24805](https://redirect.github.com/astral-sh/ruff/pull/24805))

### CLI

- Respect default Unix permissions for cache files ([#​24794](https://redirect.github.com/astral-sh/ruff/pull/24794))

### Documentation

- \[`pylint`\] Fix `PLR0124` description not to claim self-comparison always returns the same value ([#​24749](https://redirect.github.com/astral-sh/ruff/pull/24749))
- \[`pyupgrade`\] Expand docs on reusable `TypeVar`s and scoping (`UP046`) ([#​24153](https://redirect.github.com/astral-sh/ruff/pull/24153))
- Improve rules table accessibility ([#​24711](https://redirect.github.com/astral-sh/ruff/pull/24711))

### Contributors

- [@​dylwil3](https://redirect.github.com/dylwil3)
- [@​AlexWaygood](https://redirect.github.com/AlexWaygood)
- [@​woodruffw](https://redirect.github.com/woodruffw)
- [@​avasis-ai](https://redirect.github.com/avasis-ai)
- [@​Dev-iL](https://redirect.github.com/Dev-iL)
- [@​denyszhak](https://redirect.github.com/denyszhak)
- [@​ShipItAndPray](https://redirect.github.com/ShipItAndPray)

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.12)

#### [`0.15.13`](https://github.com/astral-sh/ruff/releases/tag/0.15.13)

## Release Notes

Released on 2026-05-14.

### Preview features

- Add a rule to flag lazy imports that are eagerly evaluated ([#​25016](https://redirect.github.com/astral-sh/ruff/pull/25016))
- \[`pylint`\] Standardize diagnostic message (`PLR0914`, `PLR0917`) ([#​24996](https://redirect.github.com/astral-sh/ruff/pull/24996))

### Bug fixes

- Fix `F811` false positive for class methods ([#​24933](https://redirect.github.com/astral-sh/ruff/pull/24933))
- Fix setting selection for multi-folder workspace ([#​24819](https://redirect.github.com/astral-sh/ruff/pull/24819))
- \[`eradicate`\] Fix false positive for lines with leading whitespace (`ERA001`) ([#​25122](https://redirect.github.com/astral-sh/ruff/pull/25122))
- \[`flake8-pyi`\] Fix false positive for f-string debug specifier (`PYI016`) ([#​24098](https://redirect.github.com/astral-sh/ruff/pull/24098))

### Rule changes

- Always include panic payload in panic diagnostic message ([#​24873](https://redirect.github.com/astral-sh/ruff/pull/24873))
- Restrict `PYI034` for in-place operations to enclosing class ([#​24511](https://redirect.github.com/astral-sh/ruff/pull/24511))
- Improve error message for parameters that are declared `global` ([#​24902](https://redirect.github.com/astral-sh/ruff/pull/24902))
- Update known stdlib ([#​25103](https://redirect.github.com/astral-sh/ruff/pull/25103))

### Performance

- \[`isort`\] Avoid constructing `glob::Pattern`s for literal known modules ([#​25123](https://redirect.github.com/astral-sh/ruff/pull/25123))

### CLI

- Add TOML examples to `--config` help text ([#​25013](https://redirect.github.com/astral-sh/ruff/pull/25013))
- Colorize ruff check 'All checks passed' ([#​25085](https://redirect.github.com/astral-sh/ruff/pull/25085))

### Configuration

- Increase max allowed value of `line-length` setting ([#​24962](https://redirect.github.com/astral-sh/ruff/pull/24962))

### Documentation

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.13)

#### [`0.15.14`](https://github.com/astral-sh/ruff/releases/tag/0.15.14)

## Release Notes

Released on 2026-05-21.

### Preview features

- \[`airflow`\] Implement `airflow-task-implicit-multiple-outputs` (`AIR202`) ([#​25152](https://redirect.github.com/astral-sh/ruff/pull/25152))
- \[`flake8-use-pathlib`\] Mark `PTH101` fix as unsafe when first argument is a class attribute annotated as `int` ([#​25086](https://redirect.github.com/astral-sh/ruff/pull/25086))
- \[`pylint`\] Implement `too-many-try-statements` (`W0717`) ([#​23970](https://redirect.github.com/astral-sh/ruff/pull/23970))
- \[`ruff`\] Add `incorrect-decorator-order` (`RUF074`) ([#​23461](https://redirect.github.com/astral-sh/ruff/pull/23461))
- \[`ruff`\] Add `fallible-context-manager` (`RUF075`) ([#​22844](https://redirect.github.com/astral-sh/ruff/pull/22844))

### Bug fixes

- Fix lambda formatting in interpolated string expressions ([#​25144](https://redirect.github.com/astral-sh/ruff/pull/25144))
- Treat generic `frozenset` annotations as immutable ([#​25251](https://redirect.github.com/astral-sh/ruff/pull/25251))
- \[`flake8-type-checking`\] Avoid `strict` behavior when `future-annotations` are enabled (`TC001`, `TC002`, `TC003`) ([#​25035](https://redirect.github.com/astral-sh/ruff/pull/25035))
- \[`pylint`\] Avoid false positives in `else` clause (`PLR1733`) ([#​25177](https://redirect.github.com/astral-sh/ruff/pull/25177))

### Rule changes

- \[`flake8-comprehensions`\] Skip `C417` for lambdas with positional-only parameters ([#​25272](https://redirect.github.com/astral-sh/ruff/pull/25272))
- \[`flake8-simplify`\] Preserve f-string source verbatim in `SIM101` fix ([#​25061](https://redirect.github.com/astral-sh/ruff/pull/25061))

### Performance

- Avoid unnecessary parser lookahead for operators ([#​25290](https://redirect.github.com/astral-sh/ruff/pull/25290))

### Documentation

- Update code example setting Neovim LSP log level ([#​25284](https://redirect.github.com/astral-sh/ruff/pull/25284))

### Other changes

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.14)

#### [`0.15.15`](https://github.com/astral-sh/ruff/releases/tag/0.15.15)

## Release Notes

Released on 2026-05-28.

### Preview features

- Fix Markdown closing fence handling ([#​25310](https://redirect.github.com/astral-sh/ruff/pull/25310))
- \[`pyflakes`\] Report duplicate imports in `typing.TYPE_CHECKING` block (`F811`) ([#​22560](https://redirect.github.com/astral-sh/ruff/pull/22560))

### Bug fixes

- \[`pyflakes`\] Treat function-scope bare annotations as locals per PEP 526 (`F821`) ([#​21540](https://redirect.github.com/astral-sh/ruff/pull/21540))

### Performance

- Avoid redundant `TokenValue` drops in the lexer ([#​25300](https://redirect.github.com/astral-sh/ruff/pull/25300))
- Reduce memory usage by dropping token-excess capacity and improve performance by approximating the initial tokens `Vec` size ([#​25354](https://redirect.github.com/astral-sh/ruff/pull/25354))
- Use `ThinVec` in AST to shrink `Stmt` ([#​25361](https://redirect.github.com/astral-sh/ruff/pull/25361))

### Documentation

- Fix `line-length` example for `--config` option ([#​25389](https://redirect.github.com/astral-sh/ruff/pull/25389))
- \[`flake8-comprehensions`\] Document `RecursionError` edge case in `__len__` (`C416`) ([#​25286](https://redirect.github.com/astral-sh/ruff/pull/25286))
- \[`mccabe`\] Improve example (`C901`) ([#​25287](https://redirect.github.com/astral-sh/ruff/pull/25287))
- \[`pyupgrade`\] Clarify fix safety docs (`UP007`, `UP045`) ([#​25288](https://redirect.github.com/astral-sh/ruff/pull/25288))
- \[`refurb`\] Document `FURB192` exception change for empty sequences ([#​25317](https://redirect.github.com/astral-sh/ruff/pull/25317))
- \[`ruff`\] Document false negative for user-defined types (`RUF013`) ([#​25289](https://redirect.github.com/astral-sh/ruff/pull/25289))

### Formatter

- Fix formatting of lambdas nested within f-strings ([#​25398](https://redirect.github.com/astral-sh/ruff/pull/25398))

### Server

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.15)

#### [`0.15.16`](https://github.com/astral-sh/ruff/releases/tag/0.15.16)

## Release Notes

Released on 2026-06-04.

### Preview features

- \[`flake8-async`\] Implement `yield-in-context-manager-in-async-generator` (`ASYNC119`) ([#​24644](https://redirect.github.com/astral-sh/ruff/pull/24644))
- \[`pylint`\] Narrow diagnostic range and exclude cases without exception handlers (`PLW0717`) ([#​25440](https://redirect.github.com/astral-sh/ruff/pull/25440))
- \[`ruff`\] Treat `yield` before `break` from a terminal loop as terminal (`RUF075`) ([#​25447](https://redirect.github.com/astral-sh/ruff/pull/25447))

### Bug fixes

- \[`eradicate`\] Avoid flagging `ruff:ignore` comments as code (`ERA001`) ([#​25537](https://redirect.github.com/astral-sh/ruff/pull/25537))
- \[`eradicate`\] Fix `ERA001`/`RUF100` conflict when `noqa` is on commented-out code ([#​25414](https://redirect.github.com/astral-sh/ruff/pull/25414))
- \[`pyflakes`\] Avoid removing the `format` call when it would change behavior (`F523`) ([#​25320](https://redirect.github.com/astral-sh/ruff/pull/25320))
- \[`pylint`\] Avoid syntax errors in invalid character replacements in f-strings before Python 3.12 (`PLE2510`, `PLE2512`, `PLE2513`, `PLE2514`, `PLE2515`) ([#​25544](https://redirect.github.com/astral-sh/ruff/pull/25544))
- \[`pyupgrade`\] Avoid converting `format` calls with more kinds of side effects (`UP032`) ([#​25484](https://redirect.github.com/astral-sh/ruff/pull/25484))

### Rule changes

- \[`flake8-pytest-style`\] Avoid fixes for ambiguous `argnames` and `argvalues` combinations (`PT006`) ([#​24776](https://redirect.github.com/astral-sh/ruff/pull/24776))

### Performance

- Drop excess capacity from statement suites during parsing ([#​25368](https://redirect.github.com/astral-sh/ruff/pull/25368))

### Documentation

- \[`pydocstyle`\] Improve discoverability of rules enabled for each convention ([#​24973](https://redirect.github.com/astral-sh/ruff/pull/24973))

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.16)

#### [`0.15.17`](https://github.com/astral-sh/ruff/releases/tag/0.15.17)

## Release Notes

Released on 2026-06-11.

### Preview features

- Allow human-readable names in suppression comments ([#​25614](https://redirect.github.com/astral-sh/ruff/pull/25614))
- Fix handling of `ignore` comments within a `disable`/`enable` pair ([#​25845](https://redirect.github.com/astral-sh/ruff/pull/25845))
- Prioritize human-readable names in CLI output ([#​25869](https://redirect.github.com/astral-sh/ruff/pull/25869))
- Respect diagnostic start and parent ranges and trailing comments in `ruff:ignore` suppressions ([#​25673](https://redirect.github.com/astral-sh/ruff/pull/25673))
- \[`flake8-async`\] Add `trio.as_safe_channel` to safe decorators (`ASYNC119`) ([#​25775](https://redirect.github.com/astral-sh/ruff/pull/25775))
- \[`flake8-pytest-style`\] Also check `pytest_asyncio` fixtures ([#​25375](https://redirect.github.com/astral-sh/ruff/pull/25375))
- \[`ruff`\] Ban `pytest` autouse fixtures (`RUF076`) ([#​25477](https://redirect.github.com/astral-sh/ruff/pull/25477))
- \[`pyupgrade`\] Add `from __future__ import annotations` automatically (`UP007`, `UP045`) ([#​23259](https://redirect.github.com/astral-sh/ruff/pull/23259))

### Bug fixes

- Fix diagnostic when `ruff:enable` or `ruff:disable` appears where `ruff:ignore` is expected ([#​25700](https://redirect.github.com/astral-sh/ruff/pull/25700))
- \[`pyupgrade`\] Preserve leading empty literals to avoid syntax errors (`UP032`) ([#​25491](https://redirect.github.com/astral-sh/ruff/pull/25491))

### Rule changes

- \[`flake8-pytest-style`\] Clarify diagnostic message for single parameters (`PT007`) ([#​25592](https://redirect.github.com/astral-sh/ruff/pull/25592))
- \[`numpy`\] Drop autofix for `np.in1d` (`NPY201`) ([#​25612](https://redirect.github.com/astral-sh/ruff/pull/25612))
- \[`pylint`\] Exempt Python version comparisons (`PLR2004`) ([#​25743](https://redirect.github.com/astral-sh/ruff/pull/25743))

### Performance

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.17)

#### [`0.15.18`](https://github.com/astral-sh/ruff/releases/tag/0.15.18)

## Release Notes

Released on 2026-06-18.

### Preview features

- Handle nested `ruff:ignore` comments ([#​25791](https://redirect.github.com/astral-sh/ruff/pull/25791))
- Stop displaying severity in output ([#​26050](https://redirect.github.com/astral-sh/ruff/pull/26050))
- Use human-readable names in CLI output ([#​25937](https://redirect.github.com/astral-sh/ruff/pull/25937))
- Use human-readable names in LSP and playground diagnostics ([#​26058](https://redirect.github.com/astral-sh/ruff/pull/26058))
- \[`pydocstyle`\] Prevent property docstrings starting with verbs (`D421`) ([#​23775](https://redirect.github.com/astral-sh/ruff/pull/23775))
- \[`flake8-pyi`\] Extend `PYI033` to Python files ([#​26129](https://redirect.github.com/astral-sh/ruff/pull/26129))

### Bug fixes

- Detect equivalent numeric mapping keys ([#​26009](https://redirect.github.com/astral-sh/ruff/pull/26009))
- Detect mapping keys equivalent to booleans ([#​25982](https://redirect.github.com/astral-sh/ruff/pull/25982))
- Detect repeated signed and complex dictionary keys ([#​26007](https://redirect.github.com/astral-sh/ruff/pull/26007))

### Rule changes

- \[`flake8-pyi`\] Rename `PYI033` to `legacy-type-comment` ([#​26131](https://redirect.github.com/astral-sh/ruff/pull/26131))

### Performance

- Use `ThinVec` for call keywords ([#​25999](https://redirect.github.com/astral-sh/ruff/pull/25999))
- Inline parser recovery context checks ([#​26038](https://redirect.github.com/astral-sh/ruff/pull/26038))
- Match parser keywords as bytes ([#​26037](https://redirect.github.com/astral-sh/ruff/pull/26037))
- Move value parsing out of lexing ([#​25360](https://redirect.github.com/astral-sh/ruff/pull/25360))

### Server

- Render subdiagnostics and secondary annotations as related information ([#​26011](https://redirect.github.com/astral-sh/ruff/pull/26011))

### Documentation

- Update fix availability for always-fixable rules ([#​26091](https://redirect.github.com/astral-sh/ruff/pull/26091))

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.18)

</details>

<details>
<summary><code>zizmor</code></summary>

#### [`v1.23.1`](https://github.com/zizmorcore/zizmor/releases/tag/v1.23.1)

## Bug Fixes 🐛[🔗](https://docs.zizmor.sh/release-notes/#bug-fixes)

- Fixed a bug where zizmor would error if given both a GH_TOKEN and a GITHUB_TOKEN (or ZIZMOR_GITHUB_TOKEN) via the environment ([#​1724](https://redirect.github.com/zizmorcore/zizmor/issues/1724))

#### [`v1.24.0`](https://github.com/zizmorcore/zizmor/releases/tag/v1.24.0)

## New Features 🌈[🔗](https://docs.zizmor.sh/release-notes/#new-features)

- zizmor now allows users to audit from stdin, by passing zizmor - ([#​1611](https://redirect.github.com/zizmorcore/zizmor/issues/1611))

## Enhancements 🌱[🔗](https://docs.zizmor.sh/release-notes/#enhancements)

- The [use-trusted-publishing](https://docs.zizmor.sh/audits/#use-trusted-publishing) audit now detects bun publish and bunx npm publish patterns ([#​1737](https://redirect.github.com/zizmorcore/zizmor/issues/1737))

    Many thanks to [@​shaanmajid](https://redirect.github.com/shaanmajid) for proposing and implementing this improvement!

- zizmor's CLI help and usage output now uses a custom color scheme for improved readability ([#​1747](https://redirect.github.com/zizmorcore/zizmor/issues/1747))

- The [secrets-outside-env](https://docs.zizmor.sh/audits/#secrets-outside-env) audit is now configurable with an allowlist of secret names that should not be flagged, even when referenced outside of an environment ([#​1759](https://redirect.github.com/zizmorcore/zizmor/issues/1759))

    Many thanks to [@​rmuir](https://redirect.github.com/rmuir) for proposing and implementing this improvement!

- The [dependabot-cooldown](https://docs.zizmor.sh/audits/#dependabot-cooldown) audit now emits a pedantic finding whenever it encounters a cooldown used with a multi-ecosystem-group, as the two do not interact well ([#​1780](https://redirect.github.com/zizmorcore/zizmor/issues/1780))

- Recommend gh release upload as a replacement for [svenstaro/upload-release-action](https://redirect.github.com/svenstaro/upload-release-action) in [superfluous-actions](https://docs.zizmor.sh/audits/#superfluous-actions) ([#​1801](https://redirect.github.com/zizmorcore/zizmor/issues/1801))


... [Full release notes](https://github.com/zizmorcore/zizmor/releases/tag/v1.24.0)

#### [`v1.24.1`](https://github.com/zizmorcore/zizmor/releases/tag/v1.24.1)

## Bug Fixes 🐛[🔗](https://docs.zizmor.sh/release-notes/#bug-fixes)

- Fixed a bug where the [ref-version-mismatch](https://docs.zizmor.sh/audits/#ref-version-mismatch) audit would incorrectly flag some version comments as not containing an appropriate version ([#​1900](https://redirect.github.com/zizmorcore/zizmor/issues/1900))

#### [`v1.25.0`](https://github.com/zizmorcore/zizmor/releases/tag/v1.25.0)

## New Features 🌈[🔗](https://docs.zizmor.sh/release-notes/#new-features)

- zizmor's finding severities can now be remapped on a per-audit basis. See [the configuration](https://docs.zizmor.sh/configuration/#rules-id-remap) for details ([#​1913](https://redirect.github.com/zizmorcore/zizmor/issues/1913))

    Many thanks to [@​Proximyst](https://redirect.github.com/Proximyst) for proposing and implementing this improvement!

- New audit: [github-app](https://docs.zizmor.sh/audits/#github-app) detects dangerous usages of GitHub App installation tokens ([#​1926](https://redirect.github.com/zizmorcore/zizmor/issues/1926))

- New audit: [unpinned-tools] detects actions that install tools without pinning to a specific version ([#​1820](https://redirect.github.com/zizmorcore/zizmor/issues/1820))

- zizmor now accepts the --no-ignores flag to disable all ignore comments and configurations when reporting findings ([#​1935](https://redirect.github.com/zizmorcore/zizmor/issues/1935))

- zizmor's LSP now honors the --persona flag on the CLI ([#​1943](https://redirect.github.com/zizmorcore/zizmor/issues/1943))

- zizmor is now aware of Docker-based action definitions, in addition to the pre-existing support for "composite" actions ([#​1965](https://redirect.github.com/zizmorcore/zizmor/issues/1965))

## Enhancements[🔗](https://docs.zizmor.sh/release-notes/#enhancements)

- Recommend gh issue edit --add-label / gh pr edit --add-label as a replacement for [actions-ecosystem/action-add-labels](https://redirect.github.com/actions-ecosystem/action-add-labels) in [superfluous-actions](https://docs.zizmor.sh/audits/#superfluous-actions)

- Recommend gh issue edit --remove-label / gh pr edit --remove-label as a replacement for [actions-ecosystem/action-remove-labels](https://redirect.github.com/actions-ecosystem/action-remove-labels) in [superfluous-actions](https://docs.zizmor.sh/audits/#superfluous-actions)


... [Full release notes](https://github.com/zizmorcore/zizmor/releases/tag/v1.25.0)

#### [`v1.25.1`](https://github.com/zizmorcore/zizmor/releases/tag/v1.25.1)

## Bug Fixes 🐛[🔗](https://docs.zizmor.sh/release-notes/#bug-fixes)

- Fixed a bug where the [cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning) audit would fail to consider release events as exempt from cache usage findings when filtered by a tag condition ([#​2004](https://redirect.github.com/zizmorcore/zizmor/issues/2004))

- Fixed a typo when suggesting --fix flags for findings ([#​2010](https://redirect.github.com/zizmorcore/zizmor/issues/2010))

    Many thanks to [@​0xdea](https://redirect.github.com/0xdea) for implementing this fix!

- Fixed a typo in [unpinned-tools](https://docs.zizmor.sh/audits/#unpinned-tools) annotations ([#​2008](https://redirect.github.com/zizmorcore/zizmor/issues/2008))

    Many thanks to [@​martincostello](https://redirect.github.com/martincostello) for implementing this fix!

- Fixed a bug where the [github-app](https://docs.zizmor.sh/audits/#github-app) audit would incorrectly flag some safe uses of [actions/create-github-app-token](https://redirect.github.com/actions/create-github-app-token) as unsafe ([#​2011](https://redirect.github.com/zizmorcore/zizmor/issues/2011))

#### [`v1.25.2`](https://github.com/zizmorcore/zizmor/releases/tag/v1.25.2)

## Bug Fixes 🐛[🔗](https://docs.zizmor.sh/release-notes/#bug-fixes)

- Fixed a bug where the [unpinned-tools](https://docs.zizmor.sh/audits/#unpinned-tools) audit would incorrectly flag the [aquasecurity/trivy-action](https://redirect.github.com/aquasecurity/trivy-action) action as installing an unpinned tool version, rather than [aquasecurity/setup-trivy](https://redirect.github.com/aquasecurity/setup-trivy) ([#​2018](https://redirect.github.com/zizmorcore/zizmor/issues/2018))

#### [`v1.26.0`](https://github.com/zizmorcore/zizmor/releases/tag/v1.26.0)

## New Features 🌈[🔗](https://docs.zizmor.sh/release-notes/#new-features)

- New audit: [typosquat-uses](https://docs.zizmor.sh/audits/#typosquat-uses) detects uses: clauses that reference likely typoed actions ([#​1985](https://redirect.github.com/zizmorcore/zizmor/issues/1985))

    Many thanks to [@​andrew](https://redirect.github.com/andrew) for proposing and implementing this improvement!

- New audit: [unsound-ternary](https://docs.zizmor.sh/audits/#unsound-ternary) detects pseudo-ternary expressions that don't evaluate as expected ([#​2085](https://redirect.github.com/zizmorcore/zizmor/issues/2085))

    Many thanks to [@​terror](https://redirect.github.com/terror) for proposing and implementing this improvement!

- New audit: [adhoc-packages](https://docs.zizmor.sh/audits/#adhoc-packages) detects run: steps that install packages in an ad-hoc manner ([#​2061](https://redirect.github.com/zizmorcore/zizmor/issues/2061))

    Many thanks to [@​connorshea](https://redirect.github.com/connorshea) for proposing and implementing this improvement!

## Enhancements 🌱[🔗](https://docs.zizmor.sh/release-notes/#enhancements)

- The [cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning) audit now detects additional cache disablement heuristics ([#​2053](https://redirect.github.com/zizmorcore/zizmor/issues/2053))

- The [known-vulnerable-actions](https://docs.zizmor.sh/audits/#known-vulnerable-actions) audit is now configurable. See [the configuration documentation](https://docs.zizmor.sh/audits/#known-vulnerable-actions-configuration) for details ([#​2084](https://redirect.github.com/zizmorcore/zizmor/issues/2084))

- The [excessive-permissions](https://docs.zizmor.sh/audits/#excessive-permissions) audit is now aware of the code-quality permission ([#​2088](https://redirect.github.com/zizmorcore/zizmor/issues/2088))


... [Full release notes](https://github.com/zizmorcore/zizmor/releases/tag/v1.26.0)

#### [`v1.26.1`](https://github.com/zizmorcore/zizmor/releases/tag/v1.26.1)

This is a small corrective release for [1.26.0](https://docs.zizmor.sh/release-notes/#1260).

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.0` | `2.5.1` | 2026-06-23 (6 days ago) | 2026-07-01 (in 2 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.15.18` | `0.15.20` | 2026-06-25 (4 days ago) | 2026-07-03 (in 4 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`fa8acc2e`](https://github.com/kdeldycke/repomatic/commit/fa8acc2e3ccfcc81ce786e6a830c81187aab0936) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/fa8acc2e3ccfcc81ce786e6a830c81187aab0936/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/fa8acc2e3ccfcc81ce786e6a830c81187aab0936/.github/workflows/autofix.yaml) |
| **Run** | [#4917.1](https://github.com/kdeldycke/repomatic/actions/runs/28352019279) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.0.dev0`