### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -139,7 +139,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.0.0'
+          uvx --no-progress 'click-extra==8.0.1'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -113,7 +113,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.0.0' prebake all
+        run: uvx --no-progress 'click-extra==8.0.1' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-22` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.0.0` → `8.0.1` | 2026-06-22 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.0.1`](https://github.com/kdeldycke/click-extra/releases/tag/v8.0.1)

- Redo a proper release.

**Full changelog**: [`v8.0.0...v8.0.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.0.0...v8.0.1)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.0.1-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.0.1/click-extra-8.0.1-linux-arm64.bin) | 0 / 60 | [View scan](https://www.virustotal.com/gui/file/b50df45522330acce506dea1166346d6a87c044333013a6025e09389d1a962b8) |
| [`click-extra-8.0.1-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.0.1/click-extra-8.0.1-linux-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/694c82927d199e6995afe2627e420c472a842f030a29ec4f40d06e73a9d95b94) |
| [`click-extra-8.0.1-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.0.1/click-extra-8.0.1-macos-arm64.bin) | 0 / 58 | [View scan](https://www.virustotal.com/gui/file/61c63cea2175a1d9f59d623e433397ffa801d78bf02ef50dc27acf93ffd018c0) |
| [`click-extra-8.0.1-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.0.1/click-extra-8.0.1-macos-x64.bin) | 0 / 53 | [View scan](https://www.virustotal.com/gui/file/3b7624f615911d01b9cc062766df6b5ea1d9bd7cb747d998b5875bd0a48dbe9c) |
| [`click-extra-8.0.1-windows-arm64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.0.1/click-extra-8.0.1-windows-arm64.exe) | 2 / 59 | [View scan](https://www.virustotal.com/gui/file/55843575d2f522adeac81b527ee06fed2875e0cdfc56fbe2508496290bbe83ee) |
| [`click-extra-8.0.1-windows-x64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.0.1/click-extra-8.0.1-windows-x64.exe) | 14 / 68 | [View scan](https://www.virustotal.com/gui/file/8767cc9170a8dc62c3fad196a7332e1e25c13aa29b0ef621e1927aee8ccbf53f) |

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.0.1` | `8.1.4` | 2026-06-27 (3 days ago) | 2026-07-05 (in 5 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`ebb90cad`](https://github.com/kdeldycke/repomatic/commit/ebb90cad9c40e4f0efe929dff578ffd3ce0330f1) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/ebb90cad9c40e4f0efe929dff578ffd3ce0330f1/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/ebb90cad9c40e4f0efe929dff578ffd3ce0330f1/.github/workflows/autofix.yaml) |
| **Run** | [#4921.1](https://github.com/kdeldycke/repomatic/actions/runs/28428201845) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.0.dev0`