### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-shfmt-${{ hashFiles('repomatic/tool_runner.py') }}
@@ -248,7 +248,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-biome-${{ hashFiles('repomatic/tool_runner.py') }}
@@ -291,7 +291,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-typos-${{ hashFiles('repomatic/tool_runner.py') }}
@@ -558,7 +558,7 @@ jobs:
       # Persist repomatic's HTTP cache (PyPI/GitHub/npm release metadata) across
       # runs. Entries are TTL-gated in repomatic.cache, so a restored cache never
       # serves a stale "latest" version; this mainly speeds up bursts of pushes.
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/repomatic
           key: repomatic-http-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-lychee-${{ hashFiles('repomatic/tool_runner.py') }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-labelmaker-${{ hashFiles('repomatic/tool_runner.py') }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-actionlint-${{ hashFiles('repomatic/tool_runner.py') }}
@@ -231,7 +231,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-gitleaks-${{ hashFiles('repomatic/tool_runner.py') }}


### PR DESCRIPTION
### Description

Bumps SHA-pinned GitHub Actions (`uses: owner/repo@<sha> # vX.Y.Z`) to their latest releases that have cleared the stabilization cooldown, resolving each release tag to its commit SHA. See the [`sync-action-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-23` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/cache](https://github.com/actions/cache) | [`v5.0.5` → `v6.0.0`](https://github.com/actions/cache/compare/v5.0.5...v6.0.0) | 2026-06-23 (a week ago) |

### Release notes

<details>
<summary><code>actions/cache</code></summary>

#### [`v5.1.0`](https://github.com/actions/cache/releases/tag/v5.1.0)

## What's Changed
* Bump @​actions/cache to v5.1.0 - handle read-only cache access by @​jasongin in https://redirect.github.com/actions/cache/pull/1775


**Full Changelog**: https://redirect.github.com/actions/cache/compare/v5...v5.1.0

#### [`v6.0.0`](https://github.com/actions/cache/releases/tag/v6.0.0)

## What's Changed
* Update packages, migrate to ESM by @​Samirat in https://redirect.github.com/actions/cache/pull/1760

**Full Changelog**: https://redirect.github.com/actions/cache/compare/v5...v6.0.0

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Action | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [actions/attest](https://github.com/actions/attest) | `4.1.0` | `4.1.1` | 2026-06-26 (5 days ago) | 2026-07-04 (in 3 days) |
| [actions/cache](https://github.com/actions/cache) | `6.0.0` | `6.1.0` | 2026-06-26 (5 days ago) | 2026-07-04 (in 3 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`2cdb3828`](https://github.com/kdeldycke/repomatic/commit/2cdb38286c0343fc1e001154cd75a2b06228a44b) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/2cdb38286c0343fc1e001154cd75a2b06228a44b/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/2cdb38286c0343fc1e001154cd75a2b06228a44b/.github/workflows/autofix.yaml) |
| **Run** | [#4928.1](https://github.com/kdeldycke/repomatic/actions/runs/28525768018) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.0.dev0`