### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -207,7 +207,7 @@ jobs:
         # tree) with npm's min-release-age cooldown, which needs npm 11.10.0+;
         # older npm ignores it, so provision a new-enough npm the way setup-uv
         # provisions uv. sync-workflow-pins bumps this pin like any npm literal.
-        run: npm install npm@11.10.0 --global # zizmor: ignore[adhoc-packages]
+        run: npm install npm@11.17.0 --global # zizmor: ignore[adhoc-packages]
       - name: Run awesome-lint
         run: uvx --no-progress --from . repomatic run awesome-lint
 


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-23` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [npm](https://www.npmjs.com/package/npm) | `11.10.0` → `11.17.0` | 2026-06-11 (a month ago) |

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [npm](https://www.npmjs.com/package/npm) | `11.17.0` | `11.18.0` | 2026-06-29 (2 days ago) | 2026-07-07 (in 6 days) |
| [click-extra](https://pypi.org/project/click-extra/) | `8.0.1` | `8.1.4` | 2026-06-27 (4 days ago) | 2026-07-05 (in 4 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`025060dc`](https://github.com/kdeldycke/repomatic/commit/025060dc2eb2a5f230fe7ac1344d482712df0cfd) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/025060dc2eb2a5f230fe7ac1344d482712df0cfd/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/025060dc2eb2a5f230fe7ac1344d482712df0cfd/.github/workflows/autofix.yaml) |
| **Run** | [#4932.1](https://github.com/kdeldycke/repomatic/actions/runs/28546662636) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.0.dev0`