### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -139,7 +139,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.0.1'
+          uvx --no-progress 'click-extra==8.1.1'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -113,7 +113,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.0.1' prebake all
+        run: uvx --no-progress 'click-extra==8.1.1' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-24` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.0.1` → `8.1.1` | 2026-06-24 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.1.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.0)

- **Breaking:** Rename the `test-plan` subcommand to `test-suite`, its `--plan-file`/`--plan-envvar` options to `--suite-file`/`--suite-envvar`, its `[tool.<cli>.test-plan]` config section to `[tool.<cli>.test-suite]`, the `click_extra.test_plan` module to `click_extra.test_suite`, and the `TestPlanConfig`/`parse_test_plan`/`run_test_plan`/`DEFAULT_TEST_PLAN` API to `TestSuiteConfig`/`parse_test_suite`/`run_test_suite`/`DEFAULT_TEST_SUITE`. The `CLITestCase` class and the `[[cases]]` file structure keep their names.
- **Breaking:** Replace the test-suite config's `inline` field with a native `cases` array under `[tool.<cli>.test-suite.cases]` (or set `file` to a suite path). Adds the `cases` field to `TestSuiteConfig` and the `cases_from_data` helper.
- **Breaking:** `ClickExtraConfig`, `TestSuiteConfig`, and `PrebakeConfig` are no longer re-exported from the top-level `click_extra` namespace; import them from `click_extra.config`.
- Add a [Carapace](https://carapace.sh) completion exporter: the `click_extra.carapace` module serializes a Click command tree to [carapace-spec](https://redirect.github.com/carapace-sh/carapace-spec) YAML for native shell completion, behind a new `carapace` extra. The `to_carapace_spec`, `dump_carapace_spec`, `write_carapace_spec` and `install_carapace_spec` API answers [`click#3188`](https://redirect.github.com/pallets/click/issues/3188).
- Add a `--carapace` mode to the `wrap` command: `click-extra wrap --carapace SCRIPT` prints the target CLI's spec, and `--install` writes it into Carapace's user spec directory. Mutually exclusive with `--man` and `--show-params`.
- The `wrap` command now accepts a local project directory, reading its console-script entry point from `pyproject.toml` or `setup.cfg` so a checked-out project can be wrapped without installing it first.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.0)

#### [`v8.1.1`](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.1)

- Fix `multiple` and variadic (`nargs=-1`) options typed with `EnumChoice`: their tuple default was stringified as a whole (`str((MyEnum.FOO,))`) instead of per member, so the default tripped Click's `Value must be an iterable` check when the option was left unset.
- Fix `decorator_factory` leaking options across uses of a pre-instantiated decorator: when `command()` is stored (e.g. in a pytest parametrize list) and reused, Click mutated the shared `params` list by extending it with each decorated function's options, adding duplicates on every reuse. The fix re-evaluates `params_func()` fresh on each application.

**Full changelog**: [`v8.1.0...v8.1.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.1.0...v8.1.1)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.1.1-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.1/click-extra-8.1.1-linux-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/eaefe04f7ac047957c295c8b4372a34b8a8ae77815a61c884526946dd8a31be3) |
| [`click-extra-8.1.1-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.1/click-extra-8.1.1-linux-x64.bin) | 0 / 62 | [View scan](https://www.virustotal.com/gui/file/b97c426b0eec2a841e4b13a29afa11aff0e27f4944b108a0ac9c9e059768a708) |
| [`click-extra-8.1.1-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.1/click-extra-8.1.1-macos-arm64.bin) | *pending* | [View scan](https://www.virustotal.com/gui/file/4115aef54ed12a52320b0c78cd7c80678b98438b5b9b4fb208ebcc32a828718a) |
| [`click-extra-8.1.1-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.1/click-extra-8.1.1-macos-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/0dd21cf61119135ad45f88af682056be6603b03fe492c751ae82a0b56be5a022) |

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.1)

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [npm](https://www.npmjs.com/package/npm) | `11.17.0` | `11.18.0` | 2026-06-29 (3 days ago) | 2026-07-07 (in 5 days) |
| [click-extra](https://pypi.org/project/click-extra/) | `8.1.1` | `8.2.0` | 2026-07-01 (a day ago) | 2026-07-09 (in a week) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`c882f939`](https://github.com/kdeldycke/repomatic/commit/c882f93935ab983b222f2d470db28af43e777e57) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/c882f93935ab983b222f2d470db28af43e777e57/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/c882f93935ab983b222f2d470db28af43e777e57/.github/workflows/autofix.yaml) |
| **Run** | [#4937.1](https://github.com/kdeldycke/repomatic/actions/runs/28580738434) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.1.dev0`