### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -275,11 +275,11 @@ wheels = [
 
 [[package]]
 name = "bracex"
-version = "2.6"
+version = "2.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/7c/a2a8a52db0ee751007507ddad3a1ddf1b0f763de546c588e7a828579bdad/bracex-2.7.tar.gz", hash = "sha256:4cb5d415a707f6beeb2779099486090bf98cbd8b7edbdfcb7cbea2f5fe6bdb48", size = 42150, upload-time = "2026-06-28T18:48:39.276Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/24/67865d7a710d86de496c7984e06023aa3656b5fae16ee229a530b57c0491/bracex-2.7-py3-none-any.whl", hash = "sha256:025043774188f8a05db36de9e3d4f7d82a8509a41a115cc134c44a60c36375eb", size = 11508, upload-time = "2026-06-28T18:48:38.138Z" },
 ]
 
 [[package]]
@@ -410,7 +410,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "8.1.1"
+version = "8.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -423,9 +423,9 @@ dependencies = [
     { name = "wcmatch" },
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/ee/61eb8cadbf58b3570bab603106076e46466e890f7aba19ac4a420b27511f/click_extra-8.1.1.tar.gz", hash = "sha256:d9fa8de46b5fac91c7cbb0be5e1a788f04845d01a5580f210f90761f16be7cd6", size = 306766, upload-time = "2026-06-24T15:35:08.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/96/bb6ab6d01a5e3ed728f627988e931dc2179c0ef76ac0eab06add0ce2f015/click_extra-8.1.4.tar.gz", hash = "sha256:342e8194749278e7ce78c5f28f0c2fcfa935534150dc8a4d8021229870768449", size = 307295, upload-time = "2026-06-27T11:55:12.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/46/406186bcf0963d0fcd9e89c0e00f4dcb761ad5b1ec91fbca7fd4f1909677/click_extra-8.1.1-py3-none-any.whl", hash = "sha256:73b51c2247177a2830573420d90f9bdc07dbcd2d226e34d098a7f4cd53972180", size = 333109, upload-time = "2026-06-24T15:35:07.107Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b6/12c8392b291b4564244e85c655cc701611d3e7d761a4cc3ce3dade8172a7/click_extra-8.1.4-py3-none-any.whl", hash = "sha256:8833567398a3ed49b5c60b5876a3afa357f883c51ff3fb1543578dca52e09c73", size = 333673, upload-time = "2026-06-27T11:55:11.163Z" },
 ]
 
 [package.optional-dependencies]
@@ -1593,14 +1593,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.11.0"
+version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/ac/99f66f906b15718687525fdf3601ca0b50d19c5e88d57cd4275a89355926/sphinx_autodoc_typehints-3.11.0.tar.gz", hash = "sha256:0112b322e2ebd993c0561af3c9e4615481b42dec199d665d6bacc875f3371e96", size = 82518, upload-time = "2026-06-11T18:48:34.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/f2/d99787d34d881b2352c04ce02bcdf0a61adf54b389c86d438b7a8ac3ae20/sphinx_autodoc_typehints-3.12.0.tar.gz", hash = "sha256:6571eb33c72cdc616a9945730fcb43c5bcf3685e79f1e8aea144735e43d5230d", size = 83874, upload-time = "2026-06-25T15:44:47.786Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/55/7aaa2439e77cff66a6f348bb2d9894abf2b7b153595a5b974c5c277e9145/sphinx_autodoc_typehints-3.11.0-py3-none-any.whl", hash = "sha256:4ab73fe735c33168be3f34818034581155416e8e248d32ea1b604e90bea75223", size = 41610, upload-time = "2026-06-11T18:48:33.056Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/28/fa0f2ff73b8ca7987ebaa107d369c95459741ac73567e5079b4a881a981b/sphinx_autodoc_typehints-3.12.0-py3-none-any.whl", hash = "sha256:1a639b7cf71be13c4d8a4f0b552dcfcdf32ff39ac33ecb47398acb85863c2faf", size = 42548, upload-time = "2026-06-25T15:44:46.306Z" },
 ]
 
 [[package]]
@@ -1815,14 +1815,14 @@ wheels = [
 
 [[package]]
 name = "tomlrt"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/b9/8198482b84758d1661e0cd9f80e8c92114ec9c59cf132ddef376e4321ad1/tomlrt-2.0.0.tar.gz", hash = "sha256:a2a249de01d3d28f359fda071ed4fe6d4cc4a53a18a11ac39d539b91b560f93f", size = 323510, upload-time = "2026-06-22T19:17:55.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/f2/73a934bb9a739e79ab33e5250b987b5567d2ebf566fbcccc5d4b24538965/tomlrt-2.0.1.tar.gz", hash = "sha256:608efd28f06e3790958b3305bfd65b0efe8bddc1cda4195ce92b788606aed6e9", size = 323847, upload-time = "2026-06-28T13:09:54.477Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/2a/1338b9397c5d0d1ab12484023baea1ff22a5dbca2b16f779d35c71f9d8d2/tomlrt-2.0.0-py3-none-any.whl", hash = "sha256:b34f6a0a3f174058e6d623e50c0435145e3e389a7488c955d95feceeea287a89", size = 135685, upload-time = "2026-06-22T19:17:54.351Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3c/98c35227cc62f97c58cc1b1f33e495a4d58e31bb828be73ae0b2995f3674/tomlrt-2.0.1-py3-none-any.whl", hash = "sha256:4dbfde9b4e55c65d3cb5c98d2716af6c4be97b707c233dfda098cfa85f66584b", size = 135715, upload-time = "2026-06-28T13:09:53.07Z" },
 ]
 
 [[package]]
@@ -1897,11 +1897,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.8.1"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-29`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [bracex](https://pypi.org/project/bracex/) | `2.6` → `2.7` | 2026-06-28 (a week ago) |
| [click-extra](https://pypi.org/project/click-extra/) | [`8.1.1` → `8.1.4`](https://github.com/kdeldycke/click-extra/compare/v8.1.1...v8.1.4) | 2026-06-27 (a week ago) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.11.0` → `3.12.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.11.0...3.12.0) | 2026-06-25 (a week ago) |
| [tomlrt](https://pypi.org/project/tomlrt/) | [`2.0.0` → `2.0.1`](https://github.com/dimbleby/tomlrt/compare/v2.0.0...v2.0.1) | 2026-06-28 (a week ago) |
| [wcwidth](https://pypi.org/project/wcwidth/) | [`0.8.1` → `0.8.2`](https://github.com/jquast/wcwidth/compare/0.8.1...0.8.2) | 2026-06-29 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.1.2`](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.2)

- The `runner` pytest fixture now pins `HOME` and its platform equivalents inside its isolated filesystem, making configuration-file discovery independent of the ambient environment.
- The Sphinx, MkDocs and Carapace tests now self-skip when their optional dependencies are missing, so downstream packagers no longer need to `--ignore` them.

**Full changelog**: [`v8.1.1...v8.1.2`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.1.1...v8.1.2)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.1.2-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-linux-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/86eaea291c4fe82b708071f6146114d44f76c777825711348db1196ea8feaa93) |
| [`click-extra-8.1.2-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-linux-x64.bin) | 0 / 64 | [View scan](https://www.virustotal.com/gui/file/eeaf497954f73c3b5c4a1a163375b5ad1b8430d1ae9dfd58971f79f3d8a07246) |
| [`click-extra-8.1.2-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-macos-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/370148d2573a1da0f6fe268ca804bafffcc7168d5c1e9a758d49c37161bc756f) |
| [`click-extra-8.1.2-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-macos-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/eeadc952ae1e2baf64f79187d1431fecb2c557d3cf09986732e7f71ff24051b2) |
| [`click-extra-8.1.2-windows-arm64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-windows-arm64.exe) | 2 / 68 | [View scan](https://www.virustotal.com/gui/file/812fd9a1b6b16d75b8fa65c0814e4405d788b81234f8058eef71377a334c584b) |

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.2)

#### [`v8.1.3`](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.3)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.1.3-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-linux-arm64.bin) | 0 / 63 | [View scan](https://www.virustotal.com/gui/file/80c5cc12a87b558d8ba16c62a90e5c99fa5f1c70d535acd8cb604ec05b57549b) |
| [`click-extra-8.1.3-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-linux-x64.bin) | 0 / 63 | [View scan](https://www.virustotal.com/gui/file/0ed708783c353ad71f4b74b487bc081d996fe73e5e816aee41b2f58b2ac93654) |
| [`click-extra-8.1.3-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-macos-arm64.bin) | 0 / 59 | [View scan](https://www.virustotal.com/gui/file/21d66ffb00ca46d94a60b3ad917a0166a2a1f4ab7a0be3cd9d7162137e4cf140) |
| [`click-extra-8.1.3-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-macos-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/480c22de6e54f45e45e1804fd10b1a5fc4194d7a4ecb850e61696d3179fbd25d) |
| [`click-extra-8.1.3-windows-arm64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-windows-arm64.exe) | 3 / 68 | [View scan](https://www.virustotal.com/gui/file/855ec642ca239891034a9d8f470d6088304365029923ebdf6cd72fa3cbe0e864) |
| [`click-extra-8.1.3-windows-x64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-windows-x64.exe) | 9 / 68 | [View scan](https://www.virustotal.com/gui/file/d6b30b0c2def337c9b57bbd2dcfad25e2285f243ed31d1f809cb4bcad512b187) |

#### [`v8.1.4`](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.4)

> [!NOTE]
> `8.1.4` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.1.4/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.1.4).

- Skip the `EnumChoice` shell-completion case-folding test on Click 8.3.

**Full changelog**: [`v8.1.3...v8.1.4`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.1.3...v8.1.4)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.1.4-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-linux-arm64.bin) | 0 / 59 | [View scan](https://www.virustotal.com/gui/file/7a0e5f5cd8abf8971fb857afaafe7f317ca26f8551d87e3f13cccd53ac6630fc) |
| [`click-extra-8.1.4-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-linux-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/66c18da7d3fe74d02c51f7f587d479c8f8bb23d83e331a3bd6e534d60c7e9145) |
| [`click-extra-8.1.4-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-macos-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/4fc1966e2a26fce59a467d8998adf3930481bd28b2b03303aa284608ce63a2b9) |
| [`click-extra-8.1.4-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-macos-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/3c7666fb9bc4d55a829906f71a0163de6805ca53238a7887d3a9ce87bfa74c04) |
| [`click-extra-8.1.4-windows-arm64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-windows-arm64.exe) | 2 / 69 | [View scan](https://www.virustotal.com/gui/file/e4c33ad0e681b4cbae002d5088ed013fe278c54ccf14b0892cf02d69765e5d0b) |

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.4)

</details>

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.12.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.12.0)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(annotations): render recursive type aliases by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/721


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.11.0...3.12.0

</details>

<details>
<summary><code>tomlrt</code></summary>

[Changelog](https://redirect.github.com/dimbleby/tomlrt/blob/main/CHANGELOG.md)

</details>

<details>
<summary><code>wcwidth</code></summary>

#### [`0.8.2`](https://github.com/jquast/wcwidth/releases/tag/0.8.2)

* bugfix: IndexError when 'n' exceeds length by @​gaoflow in https://redirect.github.com/jquast/wcwidth/pull/228

**Full Changelog**: https://redirect.github.com/jquast/wcwidth/compare/0.8.1...0.8.2

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window. Each becomes lockable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [aiohappyeyeballs](https://pypi.org/project/aiohappyeyeballs/) | `2.6.2` | `2.7.1` | 2026-07-01 (5 days ago) | 2026-07-08 (in 2 days) |
| [bracex](https://pypi.org/project/bracex/) | `2.7` | `3.0` | 2026-06-30 (6 days ago) | 2026-07-07 (in a day) |
| [charset-normalizer](https://pypi.org/project/charset-normalizer/) | `3.4.7` | `3.4.8` | 2026-07-06 (just now) | 2026-07-13 (in a week) |
| [click-extra](https://pypi.org/project/click-extra/) | `8.1.4` | `8.2.0` | 2026-07-01 (5 days ago) | 2026-07-08 (in 2 days) |
| [coverage](https://pypi.org/project/coverage/) | `7.14.3` | `7.15.0` | 2026-07-02 (4 days ago) | 2026-07-09 (in 3 days) |
| [pyproject-metadata](https://pypi.org/project/pyproject-metadata/) | `0.11.0` | `0.12.1` | 2026-07-04 (2 days ago) | 2026-07-11 (in 5 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.0` | `3.12.1` | 2026-07-03 (3 days ago) | 2026-07-10 (in 4 days) |
| [typing-extensions](https://pypi.org/project/typing-extensions/) | `4.15.0` | `4.16.0` | 2026-07-02 (4 days ago) | 2026-07-09 (in 3 days) |
| [wcmatch](https://pypi.org/project/wcmatch/) | `10.1` | `10.2.1` | 2026-07-02 (4 days ago) | 2026-07-09 (in 3 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`f320ca52`](https://github.com/kdeldycke/repomatic/commit/f320ca52cb142170911cd2a1cbe32bb04d5cf481) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/f320ca52cb142170911cd2a1cbe32bb04d5cf481/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/f320ca52cb142170911cd2a1cbe32bb04d5cf481/.github/workflows/autofix.yaml) |
| **Run** | [#4940.1](https://github.com/kdeldycke/repomatic/actions/runs/28816708011) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.1.dev0`