### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -181,7 +181,7 @@ jobs:
         if: >-
           github.ref == 'refs/heads/main'
           && fromJSON(needs.metadata.outputs.metadata).release_commits_matrix
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: ${{ matrix.bin_name }}
       - name: Verify binary attestation

--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-shfmt-${{ hashFiles('repomatic/tool_runner.py') }}
@@ -248,7 +248,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-biome-${{ hashFiles('repomatic/tool_runner.py') }}
@@ -291,7 +291,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-typos-${{ hashFiles('repomatic/tool_runner.py') }}
@@ -558,7 +558,7 @@ jobs:
       # Persist repomatic's HTTP cache (PyPI/GitHub/npm release metadata) across
       # runs. Entries are TTL-gated in repomatic.cache, so a restored cache never
       # serves a stale "latest" version; this mainly speeds up bursts of pushes.
-      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/repomatic
           key: repomatic-http-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-lychee-${{ hashFiles('repomatic/tool_runner.py') }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-labelmaker-${{ hashFiles('repomatic/tool_runner.py') }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-actionlint-${{ hashFiles('repomatic/tool_runner.py') }}
@@ -223,7 +223,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/repomatic/bin
           key: repomatic-bin-${{ runner.os }}-${{ runner.arch }}-gitleaks-${{ hashFiles('repomatic/tool_runner.py') }}


### PR DESCRIPTION
### Description

Bumps SHA-pinned GitHub Actions (`uses: owner/repo@<sha> # vX.Y.Z`) to their latest releases that have cleared the stabilization cooldown, resolving each release tag to its commit SHA. See the [`sync-action-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-28` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/attest](https://github.com/actions/attest) | [`v4.1.0` → `v4.1.1`](https://github.com/actions/attest/compare/v4.1.0...v4.1.1) | 2026-06-26 (a week ago) |
| [actions/cache](https://github.com/actions/cache) | [`v6.0.0` → `v6.1.0`](https://github.com/actions/cache/compare/v6.0.0...v6.1.0) | 2026-06-26 (a week ago) |

### Release notes

<details>
<summary><code>actions/attest</code></summary>

#### [`v4.1.1`](https://github.com/actions/attest/releases/tag/v4.1.1)

## What's Changed
* Bump tar from 7.5.9 to 7.5.10 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/371
* Bump tar from 7.5.10 to 7.5.11 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/375
* Bump the npm-production group across 1 directory with 2 updates by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/404
* Bump minimatch by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/399
* Bump brace-expansion from 1.1.12 to 1.1.14 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/397
* Bump undici from 6.23.0 to 6.24.1 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/381
* Bump ip-address from 10.1.0 to 10.2.0 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/411
* Bump undici from 7.25.0 to 8.2.0 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/409
* Bump tar from 7.5.11 to 7.5.17 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/429
* Bump csv-parse from 5.6.0 to 6.2.1 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/414
* Bump @​sigstore/oci from 0.6.1 to 0.7.1 by @​bdehamer in https://redirect.github.com/actions/attest/pull/432

**Full Changelog**: https://redirect.github.com/actions/attest/compare/v4.1.0...v4.1.1

</details>

<details>
<summary><code>actions/cache</code></summary>

#### [`v6.1.0`](https://github.com/actions/cache/releases/tag/v6.1.0)

## What's Changed
* Bump @​actions/cache to v6.1.0 - handle read-only cache access by @​jasongin in https://redirect.github.com/actions/cache/pull/1768


**Full Changelog**: https://redirect.github.com/actions/cache/compare/v6...v6.1.0

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`f320ca52`](https://github.com/kdeldycke/repomatic/commit/f320ca52cb142170911cd2a1cbe32bb04d5cf481) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/f320ca52cb142170911cd2a1cbe32bb04d5cf481/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/f320ca52cb142170911cd2a1cbe32bb04d5cf481/.github/workflows/autofix.yaml) |
| **Run** | [#4940.1](https://github.com/kdeldycke/repomatic/actions/runs/28816708011) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.1.dev0`