### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -139,7 +139,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.1.1'
+          uvx --no-progress 'click-extra==8.1.4'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -113,7 +113,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.1.1' prebake all
+        run: uvx --no-progress 'click-extra==8.1.4' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-28` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.1.1` → `8.1.4` | 2026-06-27 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.1.2`](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.2)

- The `runner` pytest fixture now pins `HOME` and its platform equivalents inside its isolated filesystem, making configuration-file discovery independent of the ambient environment.
- The Sphinx, MkDocs and Carapace tests now self-skip when their optional dependencies are missing, so downstream packagers no longer need to `--ignore` them.

**Full changelog**: [`v8.1.1...v8.1.2`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.1.1...v8.1.2)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.1.2-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-linux-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/86eaea291c4fe82b708071f6146114d44f76c777825711348db1196ea8feaa93) |
| [`click-extra-8.1.2-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-linux-x64.bin) | 0 / 64 | [View scan](https://www.virustotal.com/gui/file/eeaf497954f73c3b5c4a1a163375b5ad1b8430d1ae9dfd58971f79f3d8a07246) |
| [`click-extra-8.1.2-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-macos-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/370148d2573a1da0f6fe268ca804bafffcc7168d5c1e9a758d49c37161bc756f) |
| [`click-extra-8.1.2-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-macos-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/eeadc952ae1e2baf64f79187d1431fecb2c557d3cf09986732e7f71ff24051b2) |
| [`click-extra-8.1.2-windows-arm64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.2/click-extra-8.1.2-windows-arm64.exe) | 2 / 68 | [View scan](https://www.virustotal.com/gui/file/812fd9a1b6b16d75b8fa65c0814e4405d788b81234f8058eef71377a334c584b) |

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.2)

#### [`v8.1.3`](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.3)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.1.3-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-linux-arm64.bin) | 0 / 63 | [View scan](https://www.virustotal.com/gui/file/80c5cc12a87b558d8ba16c62a90e5c99fa5f1c70d535acd8cb604ec05b57549b) |
| [`click-extra-8.1.3-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-linux-x64.bin) | 0 / 63 | [View scan](https://www.virustotal.com/gui/file/0ed708783c353ad71f4b74b487bc081d996fe73e5e816aee41b2f58b2ac93654) |
| [`click-extra-8.1.3-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-macos-arm64.bin) | 0 / 59 | [View scan](https://www.virustotal.com/gui/file/21d66ffb00ca46d94a60b3ad917a0166a2a1f4ab7a0be3cd9d7162137e4cf140) |
| [`click-extra-8.1.3-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-macos-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/480c22de6e54f45e45e1804fd10b1a5fc4194d7a4ecb850e61696d3179fbd25d) |
| [`click-extra-8.1.3-windows-arm64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-windows-arm64.exe) | 3 / 68 | [View scan](https://www.virustotal.com/gui/file/855ec642ca239891034a9d8f470d6088304365029923ebdf6cd72fa3cbe0e864) |
| [`click-extra-8.1.3-windows-x64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.3/click-extra-8.1.3-windows-x64.exe) | 9 / 68 | [View scan](https://www.virustotal.com/gui/file/d6b30b0c2def337c9b57bbd2dcfad25e2285f243ed31d1f809cb4bcad512b187) |

#### [`v8.1.4`](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.4)

> [!NOTE]
> `8.1.4` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.1.4/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.1.4).

- Skip the `EnumChoice` shell-completion case-folding test on Click 8.3.

**Full changelog**: [`v8.1.3...v8.1.4`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.1.3...v8.1.4)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.1.4-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-linux-arm64.bin) | 0 / 59 | [View scan](https://www.virustotal.com/gui/file/7a0e5f5cd8abf8971fb857afaafe7f317ca26f8551d87e3f13cccd53ac6630fc) |
| [`click-extra-8.1.4-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-linux-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/66c18da7d3fe74d02c51f7f587d479c8f8bb23d83e331a3bd6e534d60c7e9145) |
| [`click-extra-8.1.4-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-macos-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/4fc1966e2a26fce59a467d8998adf3930481bd28b2b03303aa284608ce63a2b9) |
| [`click-extra-8.1.4-macos-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-macos-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/3c7666fb9bc4d55a829906f71a0163de6805ca53238a7887d3a9ce87bfa74c04) |
| [`click-extra-8.1.4-windows-arm64.exe`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.1.4/click-extra-8.1.4-windows-arm64.exe) | 2 / 69 | [View scan](https://www.virustotal.com/gui/file/e4c33ad0e681b4cbae002d5088ed013fe278c54ccf14b0892cf02d69765e5d0b) |

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.1.4)

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [npm](https://www.npmjs.com/package/npm) | `11.17.0` | `11.18.0` | 2026-06-29 (a week ago) | 2026-07-07 (in a day) |
| [click-extra](https://pypi.org/project/click-extra/) | `8.1.4` | `8.2.0` | 2026-07-01 (5 days ago) | 2026-07-09 (in 3 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`f320ca52`](https://github.com/kdeldycke/repomatic/commit/f320ca52cb142170911cd2a1cbe32bb04d5cf481) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/f320ca52cb142170911cd2a1cbe32bb04d5cf481/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/f320ca52cb142170911cd2a1cbe32bb04d5cf481/.github/workflows/autofix.yaml) |
| **Run** | [#4940.1](https://github.com/kdeldycke/repomatic/actions/runs/28816708011) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.1.dev0`