### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_runner.py
+++ b/repomatic/tool_runner.py
@@ -745,27 +745,27 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "27c9bc5994dfb5711f5f09a4c3c35749ca9c4a898a063bb062e6b932dbc2571d",
+        ): "d6bc3cf1e48e5ec631228f46ab783cb8564cef3078e124c72f7328981663f979",
         (
             LINUX,
             X86_64,
-        ): "e7df298f0551dd90bea4425779369aa3130d9817f4acc4f663ef63c327206a19",
+        ): "beb442e5c9bea7f52ae6d6eb6ae4819388a8b590492d6706b9dfffca8088f066",
         (
             MACOS,
             AARCH64,
-        ): "9b9e04f749db6b037b0ad38ba0c5cce63b185a7cc3b049e577dad3c18f4adb2c",
+        ): "08fd07b53503fc433586eecb4eeb92491dba0b31dea0aa7dc158a935734a1c4c",
         (
             MACOS,
             X86_64,
-        ): "0c7002cc808eebabe7852c8417b9deb1a5615342e6881c588b49367c6c56db8c",
+        ): "44cce7ced9643d03f0855ace64a32e7830af0eff0cf20677fc48a308db9a8c5e",
         (
             WINDOWS,
             AARCH64,
-        ): "d561b19067059dfffb1244f00313958f6fcd41c0eaa9542d7787e362118a915d",
+        ): "ef3b9b65c08d84701970f70fb67e20901c5e4da39b5b9cd2eea7c194c51addac",
         (
             WINDOWS,
             X86_64,
-        ): "84d4e71fdbb4b15b1aa83c1b1cc033aae9856d48a7a857c1381b1bd499430f7c",
+        ): "c176d3309e744c4f0d4f36c6c5a9bcd316ca977f48b874f777cd4223aa23d5ae",
     },
     "gitleaks": {
         (
@@ -888,7 +888,7 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
-    "biome": "2.5.0",
+    "biome": "2.5.1",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
     "lychee": "0.24.2",
@@ -976,7 +976,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "biome": ToolSpec(
         name="biome",
         display_name="Biome",
-        version="2.5.0",
+        version="2.5.1",
         source_url="https://github.com/biomejs/biome",
         tag_pattern=r"^@biomejs/biome@(?P<version>.+)$",
         config_docs_url="https://biomejs.dev/reference/configuration/",
@@ -1233,7 +1233,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "ruff": ToolSpec(
         name="ruff",
         display_name="Ruff",
-        version="0.15.18",
+        version="0.15.20",
         source_url="https://github.com/astral-sh/ruff",
         config_docs_url="https://docs.astral.sh/ruff/configuration/",
         cli_docs_url="https://docs.astral.sh/ruff/configuration/#command-line-interface",


### PR DESCRIPTION
### Description

Bumps the tools in the [`repomatic run`](https://kdeldycke.github.io/repomatic/tool-runner.html) registry to their latest releases that have cleared the stabilization cooldown (GitHub releases for binary tools, PyPI otherwise), refreshing binary checksums in the same pass. See the [`sync-tool-versions` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-28` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.0` → `2.5.1` | 2026-06-23 (a week ago) |
| [ruff](https://github.com/astral-sh/ruff) | `0.15.18` → `0.15.20` | 2026-06-25 (a week ago) |

### Release notes

<details>
<summary><code>biome</code></summary>

#### [`@biomejs/biome@2.5.1`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.1)

## 2.5.1

### Patch Changes

- [#​10722](https://redirect.github.com/biomejs/biome/pull/10722) [`f8a303d`](https://redirect.github.com/biomejs/biome/commit/f8a303d08b6b22f56edb8ff5e7caa665532d613a) Thanks [@​denbezrukov](https://redirect.github.com/denbezrukov)! - Fixed CSS formatter output for comments between import media queries.

  ```diff
  -@import url("print.css") print,
  -/* comment */
  -screen;
  +@import url("print.css") print, /* comment */ screen;
  ```

- [#​10738](https://redirect.github.com/biomejs/biome/pull/10738) [`9fdc560`](https://redirect.github.com/biomejs/biome/commit/9fdc5600997ef59ca7ed55ac212473de9bdb0b2a) Thanks [@​JamBalaya56562](https://redirect.github.com/JamBalaya56562)! - Fixed [#​9899](https://redirect.github.com/biomejs/biome/issues/9899): the `json` and `json-pretty` reporters now escape backslashes in a diagnostic's `location.path`. Previously, paths containing backslashes (such as Windows-style paths) were emitted unescaped, producing invalid JSON.

  ```diff
  -    "path": "src\account\setup-passkey.tsx",
  +    "path": "src\\account\\setup-passkey.tsx",
  ```

- [#​10626](https://redirect.github.com/biomejs/biome/pull/10626) [`5f837df`](https://redirect.github.com/biomejs/biome/commit/5f837df033afc34d43b398aeddc06c1d4fa491d9) Thanks [@​tom-groves](https://redirect.github.com/tom-groves)! - Fixed [#​10625](https://redirect.github.com/biomejs/biome/issues/10625): `biome migrate` no longer emits an invalid trailing comma when a renamed rule (such as `noConsoleLog` → `noConsole`) is the last member of its rule group. Previously this produced malformed output that aborted the migration of a strict-JSON `biome.json` with a parsing error.

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.1)

</details>

<details>
<summary><code>ruff</code></summary>

#### [`0.15.19`](https://github.com/astral-sh/ruff/releases/tag/0.15.19)

## Release Notes

Released on 2026-06-23.

### Preview features

- Support human-readable names when hovering suppression comments and in code actions ([#​26114](https://redirect.github.com/astral-sh/ruff/pull/26114))

### Bug fixes

- Fall back to default settings when editor-only settings are invalid ([#​26244](https://redirect.github.com/astral-sh/ruff/pull/26244))
- Fix panic when inserting text at a notebook cell boundary ([#​26111](https://redirect.github.com/astral-sh/ruff/pull/26111))

### Rule changes

- \[`pylint`\] Update fix suggestions for `__floor__`, `__trunc__`, `__length_hint__`, and `__matmul__` variants (`PLC2801`) ([#​26239](https://redirect.github.com/astral-sh/ruff/pull/26239))

### Performance

- Avoid allocating when parsing single string literals ([#​26200](https://redirect.github.com/astral-sh/ruff/pull/26200))
- Avoid reallocating singleton call arguments ([#​26223](https://redirect.github.com/astral-sh/ruff/pull/26223))
- Lazily create source files for lint diagnostics ([#​26226](https://redirect.github.com/astral-sh/ruff/pull/26226))
- Optimize formatter text width and indentation ([#​26236](https://redirect.github.com/astral-sh/ruff/pull/26236))
- Reserve capacity for builtin bindings ([#​26229](https://redirect.github.com/astral-sh/ruff/pull/26229))
- Skip repeated-key checks for singleton dictionaries ([#​26228](https://redirect.github.com/astral-sh/ruff/pull/26228))
- Use ArrayVec for qualified name segments ([#​26224](https://redirect.github.com/astral-sh/ruff/pull/26224))

### Documentation

- \[`flake8-pyi`\] Note that `PYI051` is an opinionated stylistic rule ([#​26179](https://redirect.github.com/astral-sh/ruff/pull/26179))
- \[`pyupgrade`\] Clarify `UP029` as a Python 2 compatibility rule ([#​26243](https://redirect.github.com/astral-sh/ruff/pull/26243))

### Other changes

- Publish Ruff crates to crates.io ([#​26271](https://redirect.github.com/astral-sh/ruff/pull/26271))

### Contributors

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.19)

#### [`0.15.20`](https://github.com/astral-sh/ruff/releases/tag/0.15.20)

## Release Notes

Released on 2026-06-25.

### Preview features

- Allow human-readable names in rule selectors ([#​25887](https://redirect.github.com/astral-sh/ruff/pull/25887))
- Emit a warning instead of an error for unknown rule selectors ([#​26113](https://redirect.github.com/astral-sh/ruff/pull/26113))
- Match `noqa` shebang handling in `ruff:ignore` comments ([#​26286](https://redirect.github.com/astral-sh/ruff/pull/26286))
- \[`ruff`\] Remove `pytest-fixture-autouse` (`RUF076`) ([#​26240](https://redirect.github.com/astral-sh/ruff/pull/26240), [#​26371](https://redirect.github.com/astral-sh/ruff/pull/26371))

### Documentation

- Add versioning sections to custom crate READMEs ([#​26317](https://redirect.github.com/astral-sh/ruff/pull/26317))
- Update `ruff_python_parser` README for crates.io ([#​26315](https://redirect.github.com/astral-sh/ruff/pull/26315))
- \[`perflint`\] Clarify that `PERF402` applies to any iterable ([#​26242](https://redirect.github.com/astral-sh/ruff/pull/26242))

### Contributors

- [@​dhruvmanila](https://redirect.github.com/dhruvmanila)
- [@​MichaReiser](https://redirect.github.com/MichaReiser)
- [@​ntBre](https://redirect.github.com/ntBre)
- [@​trilamsr](https://redirect.github.com/trilamsr)

## Install ruff 0.15.20

### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/ruff/releases/download/0.15.20/ruff-installer.sh | sh
```

### Install prebuilt binaries via powershell script

```sh
powershell -ExecutionPolicy Bypass -c "irm https://releases.astral.sh/github/ruff/releases/download/0.15.20/ruff-installer.ps1 | iex"
```

## Download ruff 0.15.20

|  File  | Platform | Checksum |
|--------|----------|----------|

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.20)

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.1` | `2.5.2` | 2026-07-01 (5 days ago) | 2026-07-09 (in 3 days) |
| [typos](https://github.com/crate-ci/typos) | `1.47.2` | `1.48.0` | 2026-06-30 (6 days ago) | 2026-07-08 (in 2 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`67e721b0`](https://github.com/kdeldycke/repomatic/commit/67e721b0f602f5453a3b5c5c8ed8d9e82ea72aaf) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/67e721b0f602f5453a3b5c5c8ed8d9e82ea72aaf/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/67e721b0f602f5453a3b5c5c8ed8d9e82ea72aaf/.github/workflows/autofix.yaml) |
| **Run** | [#4939.1](https://github.com/kdeldycke/repomatic/actions/runs/28770914979) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.1.dev0`