### PR TITLE
Format Python

### DIFF
--- a/repomatic/binaries_page.py
+++ b/repomatic/binaries_page.py
@@ -253,7 +253,7 @@ def render_chart_section(records: Sequence[ScanRecord]) -> str:
         f"const VT_DANGER_PCT = {FLAGGED_DANGER_PCT};\n"
         "const vtCss = getComputedStyle(document.documentElement);\n"
         "const vtColor = (name, fallback) =>\n"
-        '    vtCss.getPropertyValue(name).trim() || fallback;\n'
+        "    vtCss.getPropertyValue(name).trim() || fallback;\n"
         "const vtTint = (p) => {\n"
         '    if (p.pct === 0) { return vtColor("--sd-color-success", "#28a745"); }\n'
         "    return p.pct >= VT_DANGER_PCT\n"
@@ -280,8 +280,8 @@ def render_chart_section(records: Sequence[ScanRecord]) -> str:
         "                title: (items) => VT_TREND[items[0].dataIndex].tag,\n"
         "                label: (item) => {\n"
         "                    const p = VT_TREND[item.dataIndex];\n"
-        "                    return p.flagged + \" / \" + p.total\n"
-        "                        + \" verdicts flagged (\" + p.pct + \"%)\";\n"
+        '                    return p.flagged + " / " + p.total\n'
+        '                        + " verdicts flagged (" + p.pct + "%)";\n'
         "                },\n"
         "            }},\n"
         "        },\n"
@@ -359,8 +359,7 @@ def render_binaries_csv(
                     # out, the goal state stays calm.
                     if record.stats.flagged == 0:
                         vt_cell = (
-                            f"[{{octicon}}`shield-check;1em;sd-text-success`]"
-                            f"({vt_url})"
+                            f"[{{octicon}}`shield-check;1em;sd-text-success`]({vt_url})"
                         )
                     else:
                         pct = 100 * record.stats.flagged / record.stats.total
@@ -433,9 +432,7 @@ def update_binaries_page(page_path: Path, chart_section: str, repo_slug: str) ->
             )
         text = original
     else:
-        text = PAGE_TEMPLATE.replace(
-            "{repo_url}", f"https://github.com/{repo_slug}"
-        )
+        text = PAGE_TEMPLATE.replace("{repo_url}", f"https://github.com/{repo_slug}")
 
     before, rest = text.split(PAGE_START_MARKER, 1)
     _, after = rest.split(PAGE_END_MARKER, 1)

--- a/repomatic/cli.py
+++ b/repomatic/cli.py
@@ -4140,8 +4140,7 @@ def git_commit_push(
     "--records",
     type=file_path(resolve_path=True),
     default=None,
-    help="JSON scan history file to record detection snapshots in "
-    "(requires --poll).",
+    help="JSON scan history file to record detection snapshots in (requires --poll).",
 )
 def scan_virustotal(
     tag: str,
@@ -4198,9 +4197,7 @@ def scan_virustotal(
         )
         results = poll_detection_stats(api_key, results, rate_limit, poll_timeout)
         for result in results:
-            stats = (
-                str(result.detection_stats) if result.detection_stats else "pending"
-            )
+            stats = str(result.detection_stats) if result.detection_stats else "pending"
             echo(f"  {result.filename}: {stats}")
 
     if records:

--- a/tests/test_binaries_page.py
+++ b/tests/test_binaries_page.py
@@ -192,8 +192,7 @@ def test_csv_analysis_link_without_record():
     ]
     content = render_binaries_csv(REPO, releases, [])
     assert (
-        "[{octicon}`shield` analysis]"
-        f"(https://www.virustotal.com/gui/file/{sha})"
+        f"[{{octicon}}`shield` analysis](https://www.virustotal.com/gui/file/{sha})"
     ) in content
 
 
@@ -225,8 +224,7 @@ def test_chart_content():
     assert "cdn.jsdelivr.net/npm/chart.js@" in section
     assert "const VT_DANGER_PCT = 10;" in section
     assert (
-        '{"date": "2026-07-01", "flagged": 0, "pct": 0.0, '
-        '"tag": "v1.0.0", "total": 10}'
+        '{"date": "2026-07-01", "flagged": 0, "pct": 0.0, "tag": "v1.0.0", "total": 10}'
     ) in section
     assert (
         '{"date": "2026-07-06", "flagged": 1, "pct": 10.0, '

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -185,9 +185,7 @@ def test_commit_and_push_files_pushes(git_workdir, tmp_path):
     """A changed file is committed with the bot identity and pushed."""
     (git_workdir / "seed.txt").write_text("updated\n", encoding="utf-8")
     assert commit_and_push_files(["seed.txt"], "Record update") is True
-    remote_log = _run_git(
-        "log", "--format=%s|%an", "main", cwd=tmp_path / "remote.git"
-    )
+    remote_log = _run_git("log", "--format=%s|%an", "main", cwd=tmp_path / "remote.git")
     assert f"Record update|{COMMIT_IDENTITY_NAME}" in remote_log
 
 

--- a/tests/test_virustotal.py
+++ b/tests/test_virustotal.py
@@ -217,9 +217,7 @@ def test_upsert_scan_records_creates_file(tmp_path, sample_records):
     """The history file and its parent directories are created on demand."""
     path = tmp_path / "assets" / "scans.json"
     assert upsert_scan_records(path, sample_records) is True
-    assert load_scan_records(path) == sorted(
-        sample_records, key=lambda r: r.tag
-    )
+    assert load_scan_records(path) == sorted(sample_records, key=lambda r: r.tag)
 
 
 def test_upsert_scan_records_empty_creates_file(tmp_path):


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`f320ca52`](https://github.com/kdeldycke/repomatic/commit/f320ca52cb142170911cd2a1cbe32bb04d5cf481) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/f320ca52cb142170911cd2a1cbe32bb04d5cf481/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/f320ca52cb142170911cd2a1cbe32bb04d5cf481/.github/workflows/autofix.yaml) |
| **Run** | [#4940.1](https://github.com/kdeldycke/repomatic/actions/runs/28816708011) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.1.dev0`