### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -276,11 +276,11 @@ wheels = [
 
 [[package]]
 name = "bracex"
-version = "2.7"
+version = "3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/7c/a2a8a52db0ee751007507ddad3a1ddf1b0f763de546c588e7a828579bdad/bracex-2.7.tar.gz", hash = "sha256:4cb5d415a707f6beeb2779099486090bf98cbd8b7edbdfcb7cbea2f5fe6bdb48", size = 42150, upload-time = "2026-06-28T18:48:39.276Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/f5/4473ad9b48cd0420a2d762a3750fa0e078e23e060b1af72662e5987e5530/bracex-3.0.tar.gz", hash = "sha256:b73f718d6bd98d8419e45df02426c86e9967c179949f779340d6c3a8c83b9111", size = 43162, upload-time = "2026-06-30T00:43:35.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/24/67865d7a710d86de496c7984e06023aa3656b5fae16ee229a530b57c0491/bracex-2.7-py3-none-any.whl", hash = "sha256:025043774188f8a05db36de9e3d4f7d82a8509a41a115cc134c44a60c36375eb", size = 11508, upload-time = "2026-06-28T18:48:38.138Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2e/68781b78e764e5ccc4af1e3d27e060069c73af90234853fa80000e7ee79d/bracex-3.0-py3-none-any.whl", hash = "sha256:3833e61c2f092d5aa0468fa2e6c6e990a306185abf763b6d122f0158e59c58a5", size = 11738, upload-time = "2026-06-30T00:43:34.196Z" },
 ]
 
 [[package]]
@@ -412,7 +412,7 @@ wheels = [
 [[package]]
 name = "click-extra"
 version = "8.3.0.dev0"
-source = { git = "https://github.com/kdeldycke/click-extra.git?rev=main#1f979e3d81b9e4ed06aa575b918baf9afd5d4255" }
+source = { git = "https://github.com/kdeldycke/click-extra.git?rev=main#891106d6cb49a7efaf8604f297fbce5d4867ec62" }
 dependencies = [
     { name = "boltons" },
     { name = "click" },
@@ -1882,14 +1882,14 @@ wheels = [
 
 [[package]]
 name = "wcmatch"
-version = "10.1"
+version = "10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bracex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/98/eb989c3113908e2ef46d940a53695a1ebb4be5a732c4a4f700be8f8d682b/wcmatch-10.2.tar.gz", hash = "sha256:92204839e3e9c945e1e71d7e1e4edeab2601ed50a5c51ff4f3f97ca711eeb738", size = 132499, upload-time = "2026-06-30T00:50:07.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/73/aef4aaf16b8d785762e2b14cf321a9178cc84a1bf4c40f58320f499a2d65/wcmatch-10.2-py3-none-any.whl", hash = "sha256:f1a79e80ccbe296907b7eaf57d8d3bc49eab0b428d35f7d09986b5079b6e4a5d", size = 39742, upload-time = "2026-06-30T00:50:05.927Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-30`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [bracex](https://pypi.org/project/bracex/) | [`2.7` → `3.0`](https://github.com/facelessuser/bracex/compare/2.7...3.0) | 2026-06-30 (a week ago) |
| [wcmatch](https://pypi.org/project/wcmatch/) | [`10.1` → `10.2`](https://github.com/facelessuser/wcmatch/compare/10.1...10.2) | 2026-06-30 (a week ago) |

### Release notes

<details>
<summary><code>bracex</code></summary>

#### [`3.0`](https://github.com/facelessuser/bracex/releases/tag/3.0)

## 3.0

-   **BREAK**: If there are no expansions, `bracex` will not return an empty string by default in the list. This matches
    Bash. To get the old behavior, enable the new `return_empty` parameter to always return at least an empty string if
    expansion yields no expansions.
-   **FIX**: To better match Bash, empty expansions are not returned as empty strings.
-   **FIX**: No longer backtrack if a sequence is evaluated and is deemed to be invalid.

</details>

<details>
<summary><code>wcmatch</code></summary>

#### [`10.2`](https://github.com/facelessuser/wcmatch/releases/tag/10.2)

## 10.2

-   **NEW**: Require `bracex` 3.0 for bug fixes.
-   **NEW**: Drop support for Python 3.9 which is "end of life".

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window. Each becomes lockable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [aiohappyeyeballs](https://pypi.org/project/aiohappyeyeballs/) | `2.6.2` | `2.7.1` | 2026-07-01 (6 days ago) | 2026-07-08 (in a day) |
| [charset-normalizer](https://pypi.org/project/charset-normalizer/) | `3.4.7` | `3.4.9` | 2026-07-07 (just now) | 2026-07-14 (in a week) |
| [coverage](https://pypi.org/project/coverage/) | `7.14.3` | `7.15.0` | 2026-07-02 (5 days ago) | 2026-07-09 (in 2 days) |
| [pyproject-metadata](https://pypi.org/project/pyproject-metadata/) | `0.11.0` | `0.12.1` | 2026-07-04 (3 days ago) | 2026-07-11 (in 4 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.0` | `3.12.1` | 2026-07-03 (4 days ago) | 2026-07-10 (in 3 days) |
| [typing-extensions](https://pypi.org/project/typing-extensions/) | `4.15.0` | `4.16.0` | 2026-07-02 (5 days ago) | 2026-07-09 (in 2 days) |
| [wcmatch](https://pypi.org/project/wcmatch/) | `10.2` | `10.2.1` | 2026-07-02 (5 days ago) | 2026-07-09 (in 2 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`4d264190`](https://github.com/kdeldycke/repomatic/commit/4d2641905902de941a612dadc939077eb68dc889) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/4d2641905902de941a612dadc939077eb68dc889/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/4d2641905902de941a612dadc939077eb68dc889/.github/workflows/autofix.yaml) |
| **Run** | [#4956.1](https://github.com/kdeldycke/repomatic/actions/runs/28898528197) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0.dev0`