### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -207,7 +207,7 @@ jobs:
         # tree) with npm's min-release-age cooldown, which needs npm 11.10.0+;
         # older npm ignores it, so provision a new-enough npm the way setup-uv
         # provisions uv. sync-workflow-pins bumps this pin like any npm literal.
-        run: npm install npm@11.17.0 --global # zizmor: ignore[adhoc-packages]
+        run: npm install npm@11.18.0 --global # zizmor: ignore[adhoc-packages]
       - name: Run awesome-lint
         run: uvx --no-progress --from . repomatic run awesome-lint
 


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-29` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [npm](https://www.npmjs.com/package/npm) | `11.17.0` → `11.18.0` | 2026-06-29 (a week ago) |

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.1.4` | `8.2.0` | 2026-07-01 (6 days ago) | 2026-07-09 (in 2 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`4d264190`](https://github.com/kdeldycke/repomatic/commit/4d2641905902de941a612dadc939077eb68dc889) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/4d2641905902de941a612dadc939077eb68dc889/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/4d2641905902de941a612dadc939077eb68dc889/.github/workflows/autofix.yaml) |
| **Run** | [#4956.1](https://github.com/kdeldycke/repomatic/actions/runs/28898528197) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0.dev0`