### PR TITLE
Format Python

### DIFF
--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -453,7 +453,13 @@ def test_sync_action_pins_converges_mixed_pins_without_eligible_upgrade():
         ):
             result = runner.invoke(
                 repomatic,
-                ["sync-action-pins", "--output", "out.md", "--output-format", "markdown"],
+                [
+                    "sync-action-pins",
+                    "--output",
+                    "out.md",
+                    "--output-format",
+                    "markdown",
+                ],
             )
         assert result.exit_code == 0, result.output
         content = workflow.read_text(encoding="UTF-8")


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`32f26ad1`](https://github.com/kdeldycke/repomatic/commit/32f26ad1510873453f92d0429a91909200e23524) |
| **Job** | [`format-python`](https://github.com/kdeldycke/repomatic/blob/32f26ad1510873453f92d0429a91909200e23524/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/32f26ad1510873453f92d0429a91909200e23524/.github/workflows/autofix.yaml) |
| **Run** | [#4965.1](https://github.com/kdeldycke/repomatic/actions/runs/28919868179) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0.dev0`