### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -411,8 +411,8 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "8.3.0.dev0"
-source = { git = "https://github.com/kdeldycke/click-extra.git?rev=main#891106d6cb49a7efaf8604f297fbce5d4867ec62" }
+version = "8.3.1.dev0"
+source = { git = "https://github.com/kdeldycke/click-extra.git?rev=main#8133b8649875d241cfc14514cb6e234ca8278c57" }
 dependencies = [
     { name = "boltons" },
     { name = "click" },


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-01`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | [`8.3.0.dev0` → `8.3.1.dev0`](https://github.com/kdeldycke/click-extra/compare/v8.3.0.dev0...v8.3.1.dev0) |  |

### Release notes

<details>
<summary><code>click-extra</code></summary>

[Changelog](https://redirect.github.com/kdeldycke/click-extra/blob/main/changelog.md)

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window. Each becomes lockable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [aiohappyeyeballs](https://pypi.org/project/aiohappyeyeballs/) | `2.6.2` | `2.7.1` | 2026-07-01 (a week ago) | 2026-07-08 (just now) |
| [charset-normalizer](https://pypi.org/project/charset-normalizer/) | `3.4.7` | `3.4.9` | 2026-07-07 (a day ago) | 2026-07-14 (in 6 days) |
| [coverage](https://pypi.org/project/coverage/) | `7.14.3` | `7.15.0` | 2026-07-02 (6 days ago) | 2026-07-09 (in a day) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.0.1` | `13.1.0` | 2026-07-08 (just now) | 2026-07-15 (in a week) |
| [pyproject-metadata](https://pypi.org/project/pyproject-metadata/) | `0.11.0` | `0.12.1` | 2026-07-04 (4 days ago) | 2026-07-11 (in 3 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.0` | `3.12.1` | 2026-07-03 (5 days ago) | 2026-07-10 (in 2 days) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | `2.0.2` | `2.0.3` | 2026-07-08 (just now) | 2026-07-15 (in a week) |
| [typing-extensions](https://pypi.org/project/typing-extensions/) | `4.15.0` | `4.16.0` | 2026-07-02 (6 days ago) | 2026-07-09 (in a day) |
| [wcmatch](https://pypi.org/project/wcmatch/) | `10.2` | `10.2.1` | 2026-07-02 (6 days ago) | 2026-07-09 (in a day) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`32f26ad1`](https://github.com/kdeldycke/repomatic/commit/32f26ad1510873453f92d0429a91909200e23524) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/32f26ad1510873453f92d0429a91909200e23524/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/32f26ad1510873453f92d0429a91909200e23524/.github/workflows/autofix.yaml) |
| **Run** | [#4965.1](https://github.com/kdeldycke/repomatic/actions/runs/28919868179) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0.dev0`