### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -139,7 +139,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.1.4'
+          uvx --no-progress 'click-extra==8.2.0'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -113,7 +113,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.1.4' prebake all
+        run: uvx --no-progress 'click-extra==8.2.0' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-05` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.1.4` → `8.2.0` | 2026-07-01 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.2.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.2.0)

> [!NOTE]
> `8.2.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.2.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.2.0).

- Add a `--export-config FORMAT` option to every `@command` and `@group`: it renders the resolved configuration on `<stdout>` in any writable format (`toml`, `yaml`, `json`, `json5`, `jsonc`, `hjson`, `xml`), then exits. Adds `ExportConfigOption`, `@export_config_option` and `SERIALIZABLE_FORMATS` to the public API.
- Add `--theme=auto`: it selects the `dark` or `light` palette from the terminal background, detected from `CLITHEME`, `COLORFGBG` or a live OSC 11 query; the default stays `dark`. Adds `resolve_background` and `query_osc_background` to `click_extra.color`, `resolve_auto_theme` and `AUTO_THEME` to `click_extra.theme`.
- Add `run_lanes(func, lanes)` and `resolve_jobs(ctx, count)` to `click_extra.execution`: run each lane serially while distinct lanes run concurrently, sized by `--jobs`; expose the worker-count policy shared with `run_jobs`. A `serial_at_debug` keyword collapses both fan-outs to sequential at `DEBUG` verbosity.
- Add the always-on `matrix` Sphinx directive, rendering a package's release compatibility matrix from its git tags, for the Python interpreter (`{matrix} python`) or a dependency (`{matrix} <distribution>`) axis; a comment-marker form renders the embedded table on GitHub too.
- Add the `click-extra refresh-directives` command (wrapping `click_extra.sphinx.matrix.update_matrix_blocks`) to regenerate the tables embedded in `{matrix}` directive blocks and `<!-- matrix … -->` marker regions; its `--check` mode flags stale tables in CI.
- Publish `format_cli_prompt` in `click_extra.testing` (was the private `_format_cli_prompt`): render a themed, copy-pasteable prompt simulating a CLI invocation.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.2.0)

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [npm](https://www.npmjs.com/package/npm) | `11.18.0` | `12.0.1` | 2026-07-10 (3 days ago) | 2026-07-18 (in 5 days) |
| [click-extra](https://pypi.org/project/click-extra/) | `8.2.0` | `8.3.0` | 2026-07-08 (5 days ago) | 2026-07-16 (in 3 days) |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.2.8` | `11.3.1` | 2026-07-09 (4 days ago) | 2026-07-17 (in 4 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.0.1` | `13.1.0` | 2026-07-08 (5 days ago) | 2026-07-16 (in 3 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`eef45377`](https://github.com/kdeldycke/repomatic/commit/eef4537797daca83df59dabd0e816143b5aa0cac) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/eef4537797daca83df59dabd0e816143b5aa0cac/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/eef4537797daca83df59dabd0e816143b5aa0cac/.github/workflows/autofix.yaml) |
| **Run** | [#4978.1](https://github.com/kdeldycke/repomatic/actions/runs/29233065573) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.1.dev0`