### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_runner.py
+++ b/repomatic/tool_runner.py
@@ -755,27 +755,27 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "d6bc3cf1e48e5ec631228f46ab783cb8564cef3078e124c72f7328981663f979",
+        ): "fe69df99abdc101a66597dfeb720dd40818fc58fe96d6c53b9c2e32c5065ab7a",
         (
             LINUX,
             X86_64,
-        ): "beb442e5c9bea7f52ae6d6eb6ae4819388a8b590492d6706b9dfffca8088f066",
+        ): "ccd6adc50bb997bf4f5f91140255977f3a5cd12cbdde82d5406b8d7c7154a96b",
         (
             MACOS,
             AARCH64,
-        ): "08fd07b53503fc433586eecb4eeb92491dba0b31dea0aa7dc158a935734a1c4c",
+        ): "6289b71d281928926a50136f555f0b36b84c1fbdd5090f86f47c98abb2e74128",
         (
             MACOS,
             X86_64,
-        ): "44cce7ced9643d03f0855ace64a32e7830af0eff0cf20677fc48a308db9a8c5e",
+        ): "e5a8da8fdd6dd8f47027f7a914568d0aa71728b77ed5e9bc909c00afc344f3bf",
         (
             WINDOWS,
             AARCH64,
-        ): "ef3b9b65c08d84701970f70fb67e20901c5e4da39b5b9cd2eea7c194c51addac",
+        ): "89e9220ded685420b1ae650fd4aedeb0e97d221e13480f7a4f50f2b04cbcbe1c",
         (
             WINDOWS,
             X86_64,
-        ): "c176d3309e744c4f0d4f36c6c5a9bcd316ca977f48b874f777cd4223aa23d5ae",
+        ): "04a054ca18527404fce4e7a7aa8b882616ecc1a4afa74cfad0cb54a4b165dfb2",
     },
     "gitleaks": {
         (
@@ -869,23 +869,23 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "596d5c6b9ecf34307f68bea649178c5b45a4398fe3a1fcef9598e85aa2ccb742",
+        ): "2960ae07bc1ffe19e4895e4359394dd349c9c31de78aac3a124b6e4aeb206698",
         (
             LINUX,
             X86_64,
-        ): "7aef58932fc123b4cf4b40d86468e89a3297d80169051d7cfd13a235e05fc426",
+        ): "72a930c9a94fc3914aa56835c5b859c892a797d40c1c42638b98d93f16ff519c",
         (
             MACOS,
             AARCH64,
-        ): "23ca24a9186b5cb395b5f6c8eea8cdb02911c8980833e016454b56e90c3bd474",
+        ): "7dcaf386ec255995dcbaf629641f961574b7e8785203921115eab75cbf1ca107",
         (
             MACOS,
             X86_64,
-        ): "469a2d9fc894b0cdcec6e4fa3719b4c4638e195feee6517d4845450f8e8985c6",
+        ): "f4335c255db3d57374484e0e96505c8910c0e2fa6d8813b15de529c98f93b1a9",
         (
             WINDOWS,
             X86_64,
-        ): "f4a12400c48cc08e7f5435b64d0ecb08c54091b97c3ccabf6cea178d0969ca1f",
+        ): "ce018a2352da7c1b23bd2684019ee279d2080dc063087020e80c1247d11b0743",
     },
 }
 """Tool name to platform-keyed SHA-256 hex digest mapping.
@@ -898,12 +898,12 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
-    "biome": "2.5.1",
+    "biome": "2.5.2",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
     "lychee": "0.24.2",
     "shfmt": "3.13.1",
-    "typos": "1.47.2",
+    "typos": "1.48.0",
 }
 """Tool name to the version each checksum set was computed for.
 
@@ -1011,7 +1011,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "biome": ToolSpec(
         name="biome",
         display_name="Biome",
-        version="2.5.1",
+        version="2.5.2",
         source_url="https://github.com/biomejs/biome",
         tag_pattern=r"^@biomejs/biome@(?P<version>.+)$",
         config_docs_url="https://biomejs.dev/reference/configuration/",
@@ -1476,7 +1476,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "typos": ToolSpec(
         name="typos",
-        version="1.47.2",
+        version="1.48.0",
         source_url="https://github.com/crate-ci/typos",
         config_docs_url="https://github.com/crate-ci/typos/blob/master/docs/reference.md",
         cli_docs_url="https://github.com/crate-ci/typos/blob/master/docs/reference.md",


### PR DESCRIPTION
### Description

Bumps the tools in the [`repomatic run`](https://kdeldycke.github.io/repomatic/tool-runner.html) registry to their latest releases that have cleared the stabilization cooldown (GitHub releases for binary tools, PyPI otherwise), refreshing binary checksums in the same pass. See the [`sync-tool-versions` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-05` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.1` → `2.5.2` | 2026-07-01 (a week ago) |
| [typos](https://github.com/crate-ci/typos) | `1.47.2` → `1.48.0` | 2026-06-30 (a week ago) |

### Release notes

<details>
<summary><code>biome</code></summary>

#### [`@biomejs/biome@2.5.2`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.2)

## 2.5.2

### Patch Changes

- [#​10595](https://redirect.github.com/biomejs/biome/pull/10595) [`f458028`](https://redirect.github.com/biomejs/biome/commit/f4580289094a8fe5c85252adc3399c060bab811e) Thanks [@​pkallos](https://redirect.github.com/pkallos)! - Added the option `ignoreBooleanCoercion` to [useNullishCoalescing](https://biomejs.dev/linter/rules/use-nullish-coalescing/). When enabled, Biome ignores `||` and `||=` used inside a `Boolean()` call, where coalescing on falsy values is intentional.

- [#​10798](https://redirect.github.com/biomejs/biome/pull/10798) [`4a32b63`](https://redirect.github.com/biomejs/biome/commit/4a32b63eb41f144dc8faf6b5cdb05e1de5dbcb63) Thanks [@​pkallos](https://redirect.github.com/pkallos)! - Added the option `ignorePrimitives` to [useNullishCoalescing](https://biomejs.dev/linter/rules/use-nullish-coalescing/). When enabled, Biome ignores `||`, `||=`, and ternary expressions whose non-nullish operands are all primitives the option opts out of. Use `true` to ignore all primitives, or an object selecting `string`, `number`, `boolean`, or `bigint`.

- [#​10545](https://redirect.github.com/biomejs/biome/pull/10545) [`f3d4c00`](https://redirect.github.com/biomejs/biome/commit/f3d4c0082676c5188e9a6aa516318c7e3d59bda6) Thanks [@​Mokto](https://redirect.github.com/Mokto)! - Added the new nursery rule [`noSvelteUnnecessaryStateWrap`](https://biomejs.dev/linter/rules/no-svelte-unnecessary-state-wrap/), which reports unnecessary `$state()` wrapping of classes from `svelte/reactivity` that are already reactive.

  ```svelte
  <script>
  import { SvelteMap } from "svelte/reactivity";
  const map = $state(new SvelteMap()); // redundant
  </script>
  ```

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.2)

</details>

<details>
<summary><code>typos</code></summary>

#### [`v1.48.0`](https://github.com/crate-ci/typos/releases/tag/v1.48.0)

## [1.48.0] - 2026-06-30

### Features

- Updated the dictionary with the [June 2026](https://redirect.github.com/crate-ci/typos/issues/1562) changes

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.2` | `2.5.3` | 2026-07-08 (5 days ago) | 2026-07-16 (in 3 days) |
| [mypy](https://github.com/python/mypy) | `2.1.0` | `2.2.0` | 2026-07-08 (5 days ago) | 2026-07-16 (in 3 days) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.25.1` | `2.25.2` | 2026-07-09 (4 days ago) | 2026-07-17 (in 4 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.15.20` | `0.15.21` | 2026-07-09 (4 days ago) | 2026-07-17 (in 4 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`eef45377`](https://github.com/kdeldycke/repomatic/commit/eef4537797daca83df59dabd0e816143b5aa0cac) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/eef4537797daca83df59dabd0e816143b5aa0cac/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/eef4537797daca83df59dabd0e816143b5aa0cac/.github/workflows/autofix.yaml) |
| **Run** | [#4978.1](https://github.com/kdeldycke/repomatic/actions/runs/29233065573) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.1.dev0`