### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -139,7 +139,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.2.0'
+          uvx --no-progress 'click-extra==8.3.0'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -113,7 +113,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.2.0' prebake all
+        run: uvx --no-progress 'click-extra==8.3.0' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true

--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -62,4 +62,4 @@ jobs:
     steps:
       - uses: crazy-max/ghaction-dump-context@4d9eeaf15dd59aa4346919ea84a84ccf514b4db8 # v3.1.0
       - uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
-      - run: uvx --no-progress 'extra-platforms==13.0.1'
+      - run: uvx --no-progress 'extra-platforms==13.1.0'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -210,7 +210,7 @@ jobs:
         # tree) with npm's min-release-age cooldown, which needs npm 11.10.0+;
         # older npm ignores it, so provision a new-enough npm the way setup-uv
         # provisions uv. sync-workflow-pins bumps this pin like any npm literal.
-        run: npm install npm@11.18.0 --global # zizmor: ignore[adhoc-packages]
+        run: npm install npm@12.0.0 --global # zizmor: ignore[adhoc-packages]
       - name: Run awesome-lint
         run: uvx --no-progress --from . repomatic run awesome-lint
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -156,7 +156,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.2.8'
+          uvx --no-progress 'codecov-cli==11.3.0'
           --auto-load-params-from githubactions
           upload-process
           --git-service github


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-08` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.2.0` → `8.3.0` | 2026-07-08 (a week ago) |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.2.8` → `11.3.0` | 2026-07-08 (a week ago) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.0.1` → `13.1.0` | 2026-07-08 (a week ago) |
| [npm](https://www.npmjs.com/package/npm) | `11.18.0` → `12.0.0` | 2026-07-08 (a week ago) |

## Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.3.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.3.0)

> [!NOTE]
> `8.3.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.3.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.3.0).

- Add a `click:config` Sphinx directive documenting a CLI's `config_schema`: a summary table plus one section per option, with docstring, type, default, and a TOML example. Adds `schema_field_infos()`, `field_docstrings()` and `SchemaFieldInfo` to the public API.
- Disable mouse zoom on the class inheritance diagrams of the documentation's API sections, so they no longer hijack page scrolling; the fullscreen viewer keeps zoom.
- Add tests covering 256-color palette index `0` and empty-string colors in `Style`, gated on runtime probes of Click `8.5.0`'s color validation.

**Full changelog**: [`v8.2.0...v8.3.0`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.2.0...v8.3.0)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.3.0-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.3.0/click-extra-8.3.0-linux-arm64.bin) | 1 / 62 | [View scan](https://www.virustotal.com/gui/file/223c214c34b4776bd8374e5505c38917c0213dee574c539a27060cee1f94b7a2) |
| [`click-extra-8.3.0-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.3.0/click-extra-8.3.0-linux-x64.bin) | 1 / 64 | [View scan](https://www.virustotal.com/gui/file/d5afe22fb8402326f758c22e6a96088bf9c7d47241df9a4aa60af59b658e0bb6) |
| [`click-extra-8.3.0-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.3.0/click-extra-8.3.0-macos-arm64.bin) | 1 / 61 | [View scan](https://www.virustotal.com/gui/file/ff40b1162adc553a63e5e34b52e7b3f5ab0b120b18ee52be1717d24412791792) |

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.3.0)

</details>

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.1.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.1.0)

> [!NOTE]
> `13.1.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.1.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.1.0).

- Add ChromeOS platform detection: `CHROMEOS` / `is_chromeos()`, covering ChromeOS itself, ChromiumOS and derivatives like FydeOS, and the Crostini Linux container, where `current_platform()` prefers the container's own distribution, as with WSL.
- Add Clear Linux OS platform detection: `CLEARLINUX` / `is_clearlinux()` (via `ID=clear-linux-os` in `os-release`).
- Add SliTaz GNU/Linux platform detection: `SLITAZ` / `is_slitaz()` (via `/etc/slitaz-release`, as SliTaz ships no `os-release` file).
- Add Source Mage GNU/Linux platform detection: `SOURCEMAGE` / `is_sourcemage()` (via `ID=sourcemage` in `os-release`).
- Upload coverage to Codecov from one runner per OS, on the oldest and newest Python, instead of every test matrix cell.
- Drop the Codecov Test Analytics upload and the `junit.xml` report generation.
- Assert CLI behavior in CI with a declarative `click-extra` test suite (`tests/cli-test-suite.toml`), replacing the hand-rolled smoke invocations.
- Add the `macos-15-intel` runner to the test matrix.

**Full changelog**: [`v13.0.1...v13.1.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.0.1...v13.1.0)

</details>

## 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [npm](https://www.npmjs.com/package/npm) | `12.0.0` | `12.0.1` | 2026-07-10 (6 days ago) | 2026-07-18 (in 2 days) |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.3.0` | `11.3.1` | 2026-07-09 (a week ago) | 2026-07-17 (in a day) |

## Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`01cd602e`](https://github.com/kdeldycke/repomatic/commit/01cd602ee345e4fa71713bc5093c8cd41a589080)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/01cd602ee345e4fa71713bc5093c8cd41a589080/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/01cd602ee345e4fa71713bc5093c8cd41a589080/.github/workflows/autofix.yaml)
- **Run**: [#4992.1](https://github.com/kdeldycke/repomatic/actions/runs/29476499507)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0.dev0`