### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -96,7 +96,7 @@ jobs:
         # repomatic.init_project._serialize_file_rules emits v5+ schema
         # (`any:`/`all:` wrappers, `changed-files` matcher dicts, `head-branch`,
         # `base-branch`). Do not downgrade below v5.0.0.
-        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
         with:
           configuration-path: ".github/labeller-file-based.yaml"
 


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-12` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/labeler](https://github.com/actions/labeler) | [`v6.1.0` → `v6.2.0`](https://github.com/actions/labeler/compare/v6.1.0...v6.2.0) | 2026-07-09 (a week ago) |

### Release notes

<details>
<summary><code>actions/labeler</code></summary>

#### [`v6.2.0`](https://github.com/actions/labeler/releases/tag/v6.2.0)

##### What's Changed
###### Bug Fix
* Improve PR number validation and warning messages in input handling by @​chiranjib-swain in https://redirect.github.com/actions/labeler/pull/939
###### Dependency Updates
* Bump js-yaml to 4.2.0, apply npm audit fix, and add undici override  by @​dependabot in https://redirect.github.com/actions/labeler/pull/943
* Bump @​typescript-eslint/eslint-plugin from 8.59.1 to 8.61.1 by @​dependabot in https://redirect.github.com/actions/labeler/pull/942


**Full Changelog**: https://redirect.github.com/actions/labeler/compare/v6.1.0...v6.2.0

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Action | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [actions/attest](https://github.com/actions/attest) | `4.1.1` | `4.2.0` | 2026-07-16 (4 days ago) | 2026-07-24 (in 4 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`4bc6d440`](https://github.com/kdeldycke/repomatic/commit/4bc6d440a48a66c5f1890999446aa5d02c30d98e)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/4bc6d440a48a66c5f1890999446aa5d02c30d98e/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/4bc6d440a48a66c5f1890999446aa5d02c30d98e/.github/workflows/autofix.yaml)
- **Run**: [#5013.1](https://github.com/kdeldycke/repomatic/actions/runs/29725162325)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.1.dev0`