### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -210,7 +210,7 @@ jobs:
         # tree) with npm's min-release-age cooldown, which needs npm 11.10.0+;
         # older npm ignores it, so provision a new-enough npm the way setup-uv
         # provisions uv. sync-workflow-pins bumps this pin like any npm literal.
-        run: npm install npm@12.0.0 --global # zizmor: ignore[adhoc-packages]
+        run: npm install npm@12.0.1 --global # zizmor: ignore[adhoc-packages]
       - name: Run awesome-lint
         run: uvx --no-progress --from . repomatic run awesome-lint
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -159,7 +159,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.3.0'
+          uvx --no-progress 'codecov-cli==11.3.1'
           --auto-load-params-from githubactions
           upload-process
           --git-service github
@@ -225,7 +225,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.3.0'
+          uvx --no-progress 'codecov-cli==11.3.1'
           --auto-load-params-from githubactions
           upload-process
           --git-service github


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-12` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.3.0` → `11.3.1` | 2026-07-09 (a week ago) |
| [npm](https://www.npmjs.com/package/npm) | `12.0.0` → `12.0.1` | 2026-07-10 (a week ago) |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.3.0` | `8.4.0` | 2026-07-16 (4 days ago) | 2026-07-24 (in 4 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.1.0` | `13.3.1` | 2026-07-17 (3 days ago) | 2026-07-25 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`4bc6d440`](https://github.com/kdeldycke/repomatic/commit/4bc6d440a48a66c5f1890999446aa5d02c30d98e)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/4bc6d440a48a66c5f1890999446aa5d02c30d98e/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/4bc6d440a48a66c5f1890999446aa5d02c30d98e/.github/workflows/autofix.yaml)
- **Run**: [#5013.1](https://github.com/kdeldycke/repomatic/actions/runs/29725162325)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.1.dev0`