### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_runner.py
+++ b/repomatic/tool_runner.py
@@ -781,27 +781,27 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "fe69df99abdc101a66597dfeb720dd40818fc58fe96d6c53b9c2e32c5065ab7a",
+        ): "b642ded43aebcad738926b40eefd4dc2187a206d1fbfb37a45f1db4986804dbd",
         (
             LINUX,
             X86_64,
-        ): "ccd6adc50bb997bf4f5f91140255977f3a5cd12cbdde82d5406b8d7c7154a96b",
+        ): "ab8e74af2366127306e250652d2f32bd193601f208fcd0604112080c0ca3245b",
         (
             MACOS,
             AARCH64,
-        ): "6289b71d281928926a50136f555f0b36b84c1fbdd5090f86f47c98abb2e74128",
+        ): "610d3e1e770d373368d4ccee5a19c5e1735b0235024fcbed6ae07eb080d3bb09",
         (
             MACOS,
             X86_64,
-        ): "e5a8da8fdd6dd8f47027f7a914568d0aa71728b77ed5e9bc909c00afc344f3bf",
+        ): "4df90556830ed35e6238e4b976b942d369a5378447c8d68b260b7a38e08b26f9",
         (
             WINDOWS,
             AARCH64,
-        ): "89e9220ded685420b1ae650fd4aedeb0e97d221e13480f7a4f50f2b04cbcbe1c",
+        ): "62db4103a4aeb03de3fc1ddcd21194767298133ce874ee9ca40ca85d4fe2f05e",
         (
             WINDOWS,
             X86_64,
-        ): "04a054ca18527404fce4e7a7aa8b882616ecc1a4afa74cfad0cb54a4b165dfb2",
+        ): "04c9ca46af43a0d060b22b21f94c7e1a9e8c57963a09778b8ff1d808ed536b31",
     },
     "gitleaks": {
         (
@@ -924,7 +924,7 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
-    "biome": "2.5.2",
+    "biome": "2.5.3",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
     "lychee": "0.24.2",
@@ -1037,7 +1037,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "biome": ToolSpec(
         name="biome",
         display_name="Biome",
-        version="2.5.2",
+        version="2.5.3",
         source_url="https://github.com/biomejs/biome",
         tag_pattern=r"^@biomejs/biome@(?P<version>.+)$",
         config_docs_url="https://biomejs.dev/reference/configuration/",
@@ -1339,7 +1339,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "mypy": ToolSpec(
         name="mypy",
-        version="2.1.0",
+        version="2.2.0",
         source_url="https://github.com/python/mypy",
         config_docs_url="https://mypy.readthedocs.io/en/stable/config_file.html",
         cli_docs_url="https://mypy.readthedocs.io/en/stable/command_line.html",
@@ -1401,7 +1401,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "pyproject-fmt": ToolSpec(
         name="pyproject-fmt",
-        version="2.25.1",
+        version="2.25.2",
         source_url="https://github.com/tox-dev/pyproject-fmt",
         config_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
         cli_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
@@ -1429,7 +1429,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "ruff": ToolSpec(
         name="ruff",
         display_name="Ruff",
-        version="0.15.20",
+        version="0.15.21",
         source_url="https://github.com/astral-sh/ruff",
         config_docs_url="https://docs.astral.sh/ruff/configuration/",
         cli_docs_url="https://docs.astral.sh/ruff/configuration/#command-line-interface",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-12` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.2` → `2.5.3` | 2026-07-08 (a week ago) |
| [mypy](https://github.com/python/mypy) | `2.1.0` → `2.2.0` | 2026-07-08 (a week ago) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.25.1` → `2.25.2` | 2026-07-09 (a week ago) |
| [ruff](https://github.com/astral-sh/ruff) | `0.15.20` → `0.15.21` | 2026-07-09 (a week ago) |

### Release notes

<details>
<summary><code>biome</code></summary>

#### [`@biomejs/biome@2.5.3`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.3)

##### 2.5.3

###### Patch Changes

- [#​10815](https://redirect.github.com/biomejs/biome/pull/10815) [`86613d5`](https://redirect.github.com/biomejs/biome/commit/86613d5b01eb965b460ccefbf27f168d87774aaf) Thanks [@​WaterWhisperer](https://redirect.github.com/WaterWhisperer)! - Fixed a parser panic reported in [#​10708](https://redirect.github.com/biomejs/biome/issues/10708): Biome now recovers when unsupported CSS Modules `@value` rules or scoped `@keyframes` names end at EOF.

- [#​10534](https://redirect.github.com/biomejs/biome/pull/10534) [`da9b403`](https://redirect.github.com/biomejs/biome/commit/da9b403b6bbacc8d75d56e327a46f4ed0285913e) Thanks [@​Mokto](https://redirect.github.com/Mokto)! - Fixed [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) false positives in Svelte files: Svelte store subscriptions (`$store` references in templates now keep the underlying `store` binding from being flagged), and `$bindable()` props that are only written to in the script block (write-only is intentional for bindable props) are no longer reported as unused.

- [#​10827](https://redirect.github.com/biomejs/biome/pull/10827) [`098ba41`](https://redirect.github.com/biomejs/biome/commit/098ba41c99e6efaac8eb182eec258a567bb00123) Thanks [@​Aqu1bp](https://redirect.github.com/Aqu1bp)! - Fixed [#​10698](https://redirect.github.com/biomejs/biome/issues/10698): The [`noUnsafeOptionalChaining`](https://biomejs.dev/linter/rules/no-unsafe-optional-chaining/) rule now reports unsafe optional chains wrapped in TypeScript `as`, `satisfies`, type assertion, and instantiation expressions, such as `new (value?.constructor as Constructor)()`.

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.3)

</details>

<details>
<summary><code>pyproject-fmt</code></summary>

#### [`v2.25.2`](https://github.com/tox-dev/pyproject-fmt/releases/tag/v2.25.2)

<!-- Release notes generated using configuration in .github/release.yaml at v2.25.2 -->

**Full Changelog**: https://redirect.github.com/tox-dev/pyproject-fmt/compare/v2.25.1...v2.25.2

</details>

<details>
<summary><code>ruff</code></summary>

#### [`0.15.21`](https://github.com/astral-sh/ruff/releases/tag/0.15.21)

##### Release Notes

Released on 2026-07-09.

###### Preview features

- Add `--add-ignore` for adding `ruff:ignore` comments ([#​26346](https://redirect.github.com/astral-sh/ruff/pull/26346))
- \[`flake8-comprehensions`\] Drop `C409` tuple comprehension preview behavior ([#​25707](https://redirect.github.com/astral-sh/ruff/pull/25707))
- Avoid whitespace normalization when formatting comments ([#​26455](https://redirect.github.com/astral-sh/ruff/pull/26455))
- \[`pyupgrade`\] Lint and fix use of deprecated `abc` decorators (`UP051`) ([#​26417](https://redirect.github.com/astral-sh/ruff/pull/26417))

###### Bug fixes

- Refine non-empty f-string detection ([#​26526](https://redirect.github.com/astral-sh/ruff/pull/26526))
- Detect syntax errors in individual notebook cells ([#​26419](https://redirect.github.com/astral-sh/ruff/pull/26419))
- \[`flake8-implicit-str-concat`\] Fix `ISC003` autofix incorrectly stripping `+` from comments ([#​26554](https://redirect.github.com/astral-sh/ruff/pull/26554))

###### Rule changes

- \[`flake8-executable`\] Mark `EXE004` fix as unsafe ([#​26033](https://redirect.github.com/astral-sh/ruff/pull/26033))
- \[`flake8-pyi`\] Mark `PYI061` fixes as unsafe in Python files ([#​26533](https://redirect.github.com/astral-sh/ruff/pull/26533))
- \[`pydocstyle`\] Skip `overload-with-docstring` in stub files (`D418`) ([#​26318](https://redirect.github.com/astral-sh/ruff/pull/26318))

###### Performance

- Avoid per-token source index visitor calls ([#​26506](https://redirect.github.com/astral-sh/ruff/pull/26506))
- Cache parenthesized expression boundaries in the formatter ([#​26344](https://redirect.github.com/astral-sh/ruff/pull/26344))
- Improve performance of rendering edits in preview mode ([#​26565](https://redirect.github.com/astral-sh/ruff/pull/26565))
- Inline `fits_element` in formatter ([#​26429](https://redirect.github.com/astral-sh/ruff/pull/26429))

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.21)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.3` | `2.5.4` | 2026-07-15 (5 days ago) | 2026-07-23 (in 3 days) |
| [mypy](https://github.com/python/mypy) | `2.2.0` | `2.3.0` | 2026-07-13 (a week ago) | 2026-07-21 (in a day) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.25.2` | `2.25.3` | 2026-07-13 (a week ago) | 2026-07-21 (in a day) |
| [ruff](https://github.com/astral-sh/ruff) | `0.15.21` | `0.15.22` | 2026-07-16 (4 days ago) | 2026-07-24 (in 4 days) |
| [zizmor](https://github.com/zizmorcore/zizmor) | `1.26.1` | `1.27.0` | 2026-07-14 (6 days ago) | 2026-07-22 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://kdeldycke.github.io/repomatic/workflows.html#sync-tool-versions-updater)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`4bc6d440`](https://github.com/kdeldycke/repomatic/commit/4bc6d440a48a66c5f1890999446aa5d02c30d98e)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/4bc6d440a48a66c5f1890999446aa5d02c30d98e/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/4bc6d440a48a66c5f1890999446aa5d02c30d98e/.github/workflows/autofix.yaml)
- **Run**: [#5013.1](https://github.com/kdeldycke/repomatic/actions/runs/29725162325)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.1.dev0`