### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -62,4 +62,4 @@ jobs:
     steps:
       - uses: crazy-max/ghaction-dump-context@4d9eeaf15dd59aa4346919ea84a84ccf514b4db8 # v3.1.0
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-      - run: uvx --no-progress 'extra-platforms==13.1.0'
+      - run: uvx --no-progress 'extra-platforms==13.2.0'


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-15` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.1.0` → `13.2.0` | 2026-07-15 (a week ago) |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.2.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.2.0)

> [!NOTE]
> `13.2.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.2.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.2.0).

- Add PikaOS platform detection: `PIKAOS` / `is_pikaos()` (via `ID=pika` in `os-release`). Closes [#​610](https://redirect.github.com/kdeldycke/extra-platforms/issues/610)
- Document installation from AUR, GNU Guix, openSUSE Tumbleweed and pkgsrc.

**Full changelog**: [`v13.1.0...v13.2.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.1.0...v13.2.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.3.0` | `8.4.0` | 2026-07-16 (a week ago) | 2026-07-24 (in a day) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.2.0` | `13.3.1` | 2026-07-17 (6 days ago) | 2026-07-25 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`d8eebbc6`](https://github.com/kdeldycke/repomatic/commit/d8eebbc65d64c4a9c5e87f2215e0d398772dcd3a)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/d8eebbc65d64c4a9c5e87f2215e0d398772dcd3a/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/d8eebbc65d64c4a9c5e87f2215e0d398772dcd3a/.github/workflows/autofix.yaml)
- **Run**: [#5026.1](https://github.com/kdeldycke/repomatic/actions/runs/30002733368)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0.dev0`