### PR TITLE
Bump minor version to `v7.4.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`7.3.2.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v7.3.1...main)
+## [`7.4.0.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v7.3.1...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9,<0.12" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "repomatic"
-version = "7.3.2.dev0"
+version = "7.4.0.dev0"
 description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 readme = "readme.md"
 keywords = [
@@ -133,7 +133,7 @@ dependencies = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/repomatic/blob/main/changelog.md"
 urls.Documentation = "https://kdeldycke.github.io/repomatic"
-urls.Download = "https://github.com/kdeldycke/repomatic/releases/tag/v7.3.2.dev0"
+urls.Download = "https://github.com/kdeldycke/repomatic/releases/tag/v7.4.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/repomatic"
 urls.Issues = "https://github.com/kdeldycke/repomatic/issues"
@@ -230,7 +230,7 @@ copyright = "Kevin Deldycke <kevin@deldycke.com> and contributors. Distributed u
 file-description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 # Numeric only: Nuitka rejects PEP 440 .devN suffixes. Kept in sync with the
 # package version by the dedicated [tool.bumpversion] rule that strips the suffix.
-file-version = "7.3.2"
+file-version = "7.4.0"
 include-data-dir = [
   "repomatic/data/awesome_template=repomatic/data/awesome_template",
 ]
@@ -248,7 +248,7 @@ include-package-data = [ "click_extra" ]
 linux-icon = "docs/assets/icon.png"
 macos-app-icon = "docs/assets/icon.icns"
 product-name = "Repomatic"
-product-version = "7.3.2"
+product-version = "7.4.0"
 windows-icon-from-ico = "docs/assets/icon.ico"
 
 [tool.ruff]
@@ -370,7 +370,7 @@ run.source = [ "repomatic" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "7.3.2.dev0"
+current_version = "7.4.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/repomatic/__init__.py
+++ b/repomatic/__init__.py
@@ -17,5 +17,5 @@
 
 from __future__ import annotations
 
-__version__ = "7.3.2.dev0"
+__version__ = "7.4.0.dev0"
 __git_tag_sha__ = ""

--- a/uv.lock
+++ b/uv.lock
@@ -1408,7 +1408,7 @@ wheels = [
 
 [[package]]
 name = "repomatic"
-version = "7.3.2.dev0"
+version = "7.4.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

## To bump version to `v7.4.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`bump-version`](https://kdeldycke.github.io/repomatic/workflows.html#bump-version-bump-version)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`f7048779`](https://github.com/kdeldycke/repomatic/commit/f7048779545296ee3d9cb494b8f50c6aed381af8)
- **Job**: [`bump-version`](https://github.com/kdeldycke/repomatic/blob/f7048779545296ee3d9cb494b8f50c6aed381af8/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/f7048779545296ee3d9cb494b8f50c6aed381af8/.github/workflows/changelog.yaml)
- **Run**: [#4606.1](https://github.com/kdeldycke/repomatic/actions/runs/30479733509)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.0.dev0`