### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -191,7 +191,7 @@ jobs:
         if: >-
           github.ref == 'refs/heads/main'
           && fromJSON(needs.metadata.outputs.metadata).release_commits_matrix
-        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
         with:
           subject-path: ${{ matrix.bin_name }}
       - name: Verify binary attestation


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-16` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/attest](https://github.com/actions/attest) | [`v4.1.1` → `v4.2.0`](https://github.com/actions/attest/compare/v4.1.1...v4.2.0) | 2026-07-16 (a week ago) |

### Release notes

<details>
<summary><code>actions/attest</code></summary>

#### [`v4.2.0`](https://github.com/actions/attest/releases/tag/v4.2.0)

##### What's Changed
* fix: split checksums on any line ending so LF files parse on Windows by @​bdehamer in https://redirect.github.com/actions/attest/pull/443
* Bump @​actions/glob from 0.6.1 to 0.7.0 in the npm-production group across 1 directory by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/435
* Bump csv-parse from 6.2.1 to 7.0.1 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/437
* Read subjects from GITHUB_ARTIFACTS_LIST by @​bdehamer in https://redirect.github.com/actions/attest/pull/447
* Support SHA-2 subject digests by @​bdehamer in https://redirect.github.com/actions/attest/pull/446


**Full Changelog**: https://redirect.github.com/actions/attest/compare/v4.1.1...v4.2.0

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Action | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [actions/checkout](https://github.com/actions/checkout) | `7.0.0` | `7.0.1` | 2026-07-20 (4 days ago) | 2026-07-28 (in 4 days) |
| [actions/labeler](https://github.com/actions/labeler) | `6.2.0` | `7.0.0` | 2026-07-21 (3 days ago) | 2026-07-29 (in 5 days) |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | `8.3.2` | `9.0.0` | 2026-07-21 (3 days ago) | 2026-07-29 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`fe62db75`](https://github.com/kdeldycke/repomatic/commit/fe62db75ce98df486563ce85bd6a95302d46223d)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/fe62db75ce98df486563ce85bd6a95302d46223d/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/fe62db75ce98df486563ce85bd6a95302d46223d/.github/workflows/autofix.yaml)
- **Run**: [#5032.1](https://github.com/kdeldycke/repomatic/actions/runs/30085918951)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.1.dev0`