### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -139,7 +139,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.3.0'
+          uvx --no-progress 'click-extra==8.4.0'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -113,7 +113,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.3.0' prebake all
+        run: uvx --no-progress 'click-extra==8.4.0' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-16` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.3.0` → `8.4.0` | 2026-07-16 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.4.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.4.0)

> [!NOTE]
> `8.4.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.4.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.4.0).

- **Breaking:** Remove the historical `from click_extra.version import prebake_*` compatibility imports; the pre-baking helpers are only importable from `click_extra.prebake`.
- **Breaking:** Remove the leaked `annotations` and `warnings` entries from the package's public API: both were star-import artifacts, not Click, Cloup or Click Extra API.
- **Breaking:** Move `args_cleanup`, `format_cli_prompt`, `PROMPT` and `INDENT` from `click_extra.testing` to `click_extra.execution`; all but `PROMPT` stay importable from their historical home.
- **Breaking:** Remove the dead `CarapaceCompletion.is_empty()` method and the deprecated alert parser's `current_depth()`.
- Add a `--tree` flag to the default option set: it prints the whole hierarchy of nested subcommands as a tree (names, aliases, operand metavars and one-line descriptions), then exits. The new `click_extra.tree` module exposes `render_command_tree()`, `TreeOption` and `@tree_option`.
- Add a `--tree` mode to `click-extra wrap`: prints the subcommand tree of any foreign Click CLI without running it, with the same target resolution as `--show-params` and `--man`.
- Help screens and the `--tree` view now style subcommand aliases with the `alias` theme slot and their parenthetical punctuation with `alias_secondary`; aliases used to take the `subcommand` slot and the punctuation stayed plain.
- Table formats able to express styles natively (`html`, `unsafehtml`, `mediawiki`, `textile`, `jira` and the four `latex*` variants) now translate the ANSI codes carried by cells and headers to the format's own styling markup instead of stripping them.
- An explicit `--color` no longer injects raw ANSI codes into the markup formats supporting native styling; the raw passthrough escape hatch remains for the formats without.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.4.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.4.0` | `8.5.0` | 2026-07-22 (2 days ago) | 2026-07-30 (in 6 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.2.0` | `13.3.1` | 2026-07-17 (a week ago) | 2026-07-25 (in a day) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`fe62db75`](https://github.com/kdeldycke/repomatic/commit/fe62db75ce98df486563ce85bd6a95302d46223d)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/fe62db75ce98df486563ce85bd6a95302d46223d/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/fe62db75ce98df486563ce85bd6a95302d46223d/.github/workflows/autofix.yaml)
- **Run**: [#5032.1](https://github.com/kdeldycke/repomatic/actions/runs/30085918951)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.1.dev0`