### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -62,4 +62,4 @@ jobs:
     steps:
       - uses: crazy-max/ghaction-dump-context@4d9eeaf15dd59aa4346919ea84a84ccf514b4db8 # v3.1.0
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-      - run: uvx --no-progress 'extra-platforms==13.2.0'
+      - run: uvx --no-progress 'extra-platforms==13.3.1'


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-19` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.2.0` → `13.3.1` | 2026-07-17 (a week ago) |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.3.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0)

> [!NOTE]
> `13.3.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.3.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0).

- Deprecate the `TUMBLEWEED` platform: openSUSE Tumbleweed is now detected as `OPENSUSE`. `TUMBLEWEED`, `is_tumbleweed()` and the `skip_tumbleweed`/`unless_tumbleweed` decorators still resolve to their `OPENSUSE` counterparts with a `DeprecationWarning`, and will be removed in `14.0.0`.
- Detect all openSUSE release channels (Tumbleweed, Leap, Slowroll, MicroOS, ...) as `OPENSUSE`. Closes [#​619](https://redirect.github.com/kdeldycke/extra-platforms/issues/619)
- `Platform.info()` now reports the raw `os-release` ID of distribution sub-variants in its `distro_id` field (like `ol` or `opensuse-slowroll`) instead of aliasing it to the canonical platform ID.
- Rename `NON_OVERLAPPING_GROUPS` to `CANONICAL_GROUPS` and `EXTRA_GROUPS` to `NON_CANONICAL_GROUPS`, matching the `Group.canonical` vocabulary. The old names still resolve with a `DeprecationWarning`, and will be removed in `14.0.0`.
- `Trait.info()` is now implemented by the base class with identity metadata: custom `Trait` subclasses are no longer forced to override it.
- Rename the `ALL_CI` group to "All CI systems" and `ALL_AGENTS` to "All AI coding agents", aligning with the other "all" group names.
- `current_traits()` now returns an immutable `frozenset`: mutating the previously returned `set` corrupted its cache.
- `linux_info()` now returns `None` for missing fields instead of empty strings, like `macos_info()` and `windows_info()`.
- Fix pytest decorator skip reasons mangling acronyms and brand names ("Skip cI systems" is now "Skip All CI systems").
- Fix grammar and labels of the `current_*()` multiple-match errors ("Multiple CI matches:" is now "Multiple CI systems match:").
- Fix the `cff-version` schema field in `citation.cff` being overwritten with the package version on every version bump.

... [Full release notes](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0)

#### [`v13.3.1`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.1)

> [!NOTE]
> `13.3.1` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.3.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.3.1).

- Fix `test_current_funcs` failing under nested shells: extra shells backed by real ancestor processes (like a fish session running an OBS chroot build) are now accounted for. Addresses [#​619](https://redirect.github.com/kdeldycke/extra-platforms/issues/619)
- Document detection semantics on every trait page: which traits can match simultaneously (shells, platforms, terminals), which are exclusive (architectures, CI systems, agents), and how each `current_*()` function arbitrates or reports absences.
- Skip the whole test workflow on version-bump pushes and pull requests.
- Skip the package install checks on pull requests: they exercise the released package, not the change under review.
- Run the test suite in parallel outside CI too, by moving `--numprocesses=auto` and `--dist=loadgroup` to pytest `addopts`.

**Full changelog**: [`v13.3.0...v13.3.1`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.3.0...v13.3.1)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.4.0` | `8.6.0` | 2026-07-24 (3 days ago) | 2026-08-01 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`501d4a1b`](https://github.com/kdeldycke/repomatic/commit/501d4a1be9cd2106fa442d91c512dd0ee2ab6d11)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/501d4a1be9cd2106fa442d91c512dd0ee2ab6d11/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/501d4a1be9cd2106fa442d91c512dd0ee2ab6d11/.github/workflows/autofix.yaml)
- **Run**: [#5044.1](https://github.com/kdeldycke/repomatic/actions/runs/30241464957)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.1.dev0`