### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_runner.py
+++ b/repomatic/tool_runner.py
@@ -820,27 +820,27 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "b642ded43aebcad738926b40eefd4dc2187a206d1fbfb37a45f1db4986804dbd",
+        ): "698199017fc0b0c865d9a0ca2074102eb1fd0b358fd164595f3960b004fe4b90",
         (
             LINUX,
             X86_64,
-        ): "ab8e74af2366127306e250652d2f32bd193601f208fcd0604112080c0ca3245b",
+        ): "4cd66b4a2953197e0e169f24b8a6e5f0fc42b3e852c3f58e562866244f3e11db",
         (
             MACOS,
             AARCH64,
-        ): "610d3e1e770d373368d4ccee5a19c5e1735b0235024fcbed6ae07eb080d3bb09",
+        ): "1250bb41a0409cf6c3133fc47819237eb61251624297f87158d2bed3ec123c3c",
         (
             MACOS,
             X86_64,
-        ): "4df90556830ed35e6238e4b976b942d369a5378447c8d68b260b7a38e08b26f9",
+        ): "b3dfae5422dbd86272bb8ed40afec66670ea7754531d8fbcbae7e445e5430387",
         (
             WINDOWS,
             AARCH64,
-        ): "62db4103a4aeb03de3fc1ddcd21194767298133ce874ee9ca40ca85d4fe2f05e",
+        ): "95bf56ccd99e090adf43127328e456b63422eb201471746b1d21c7aa33349005",
         (
             WINDOWS,
             X86_64,
-        ): "04c9ca46af43a0d060b22b21f94c7e1a9e8c57963a09778b8ff1d808ed536b31",
+        ): "49d1ef3925d31b2f08c00b76786621bf4603fdb4c3bfeff1aa2cd4d98de3a27c",
     },
     "gitleaks": {
         (
@@ -963,7 +963,7 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
-    "biome": "2.5.3",
+    "biome": "2.5.4",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
     "lychee": "0.24.2",
@@ -1076,7 +1076,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "biome": ToolSpec(
         name="biome",
         display_name="Biome",
-        version="2.5.3",
+        version="2.5.4",
         source_url="https://github.com/biomejs/biome",
         tag_pattern=r"^@biomejs/biome@(?P<version>.+)$",
         config_docs_url="https://biomejs.dev/reference/configuration/",
@@ -1378,7 +1378,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "mypy": ToolSpec(
         name="mypy",
-        version="2.2.0",
+        version="2.3.0",
         source_url="https://github.com/python/mypy",
         config_docs_url="https://mypy.readthedocs.io/en/stable/config_file.html",
         cli_docs_url="https://mypy.readthedocs.io/en/stable/command_line.html",
@@ -1440,7 +1440,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "pyproject-fmt": ToolSpec(
         name="pyproject-fmt",
-        version="2.25.2",
+        version="2.25.3",
         source_url="https://github.com/tox-dev/pyproject-fmt",
         config_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
         cli_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
@@ -1468,7 +1468,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "ruff": ToolSpec(
         name="ruff",
         display_name="Ruff",
-        version="0.15.21",
+        version="0.15.22",
         source_url="https://github.com/astral-sh/ruff",
         config_docs_url="https://docs.astral.sh/ruff/configuration/",
         cli_docs_url="https://docs.astral.sh/ruff/configuration/#command-line-interface",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-19` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.3` → `2.5.4` | 2026-07-15 (a week ago) |
| [mypy](https://github.com/python/mypy) | `2.2.0` → `2.3.0` | 2026-07-13 (2 weeks ago) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.25.2` → `2.25.3` | 2026-07-13 (2 weeks ago) |
| [ruff](https://github.com/astral-sh/ruff) | `0.15.21` → `0.15.22` | 2026-07-16 (a week ago) |

### Release notes

<details>
<summary><code>biome</code></summary>

#### [`@biomejs/biome@2.5.4`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.4)

##### 2.5.4

###### Patch Changes

- [#​10665](https://redirect.github.com/biomejs/biome/pull/10665) [`55ff995`](https://redirect.github.com/biomejs/biome/commit/55ff995098148446b7e7fdfc19053902bb987122) Thanks [@​dyc3](https://redirect.github.com/dyc3)! - Improved the performance of the HTML parser slightly in our synthetic benchmarks.

- [#​10894](https://redirect.github.com/biomejs/biome/pull/10894) [`f4fb10e`](https://redirect.github.com/biomejs/biome/commit/f4fb10e176e537e8ce2cac0c3fd4c38a77f91886) Thanks [@​ematipico](https://redirect.github.com/ematipico)! - Fixed [#​6392](https://redirect.github.com/biomejs/biome/issues/6392): On-type formatting no longer moves comments before an `if` statement into its body.

- [#​10939](https://redirect.github.com/biomejs/biome/pull/10939) [`f2799db`](https://redirect.github.com/biomejs/biome/commit/f2799db38e3d8a644207d9b8f957abea6cb3d9fa) Thanks [@​Netail](https://redirect.github.com/Netail)! - Fixed [#​10930](https://redirect.github.com/biomejs/biome/issues/10930): [`noLabelWithoutControl`](https://biomejs.dev/linter/rules/no-label-without-control/) now correctly detects text interpolation in Astro, Svelte & Vue as valid accessible content.

- [#​10945](https://redirect.github.com/biomejs/biome/pull/10945) [`ae15d98`](https://redirect.github.com/biomejs/biome/commit/ae15d98bbf2222fbb34e3e31832cba9676a6d01c) Thanks [@​Netail](https://redirect.github.com/Netail)! - Fixed [#​10942](https://redirect.github.com/biomejs/biome/issues/10942): Svelte directives don't throw an accidental debug log anymore.

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.4)

</details>

<details>
<summary><code>pyproject-fmt</code></summary>

#### [`v2.25.3`](https://github.com/tox-dev/pyproject-fmt/releases/tag/v2.25.3)

<!-- Release notes generated using configuration in .github/release.yaml at v2.25.3 -->

**Full Changelog**: https://redirect.github.com/tox-dev/pyproject-fmt/compare/v2.25.2...v2.25.3

</details>

<details>
<summary><code>ruff</code></summary>

#### [`0.15.22`](https://github.com/astral-sh/ruff/releases/tag/0.15.22)

##### Release Notes

Released on 2026-07-16.

###### Preview features

- \[`pycodestyle`\] Add an autofix for `E402` ([#​22212](https://redirect.github.com/astral-sh/ruff/pull/22212))
- \[`refurb`\] Allow subclassing builtins in stub files (`FURB189`) ([#​26812](https://redirect.github.com/astral-sh/ruff/pull/26812))
- \[`ruff`\] Add rule to replace `noqa` comments with `ruff:ignore` (`RUF105`) ([#​26423](https://redirect.github.com/astral-sh/ruff/pull/26423))
- \[`ruff`\] Add rule to use human-readable names in `ruff:ignore` comments (`RUF106`) ([#​26682](https://redirect.github.com/astral-sh/ruff/pull/26682))
- \[`ruff`\] Add rule to use human-readable names in configuration selectors (`RUF201`) ([#​26772](https://redirect.github.com/astral-sh/ruff/pull/26772))

###### Bug fixes

- \[`flake8-pyi`\] Fix false positive in `__all__` (`PYI053`) ([#​26872](https://redirect.github.com/astral-sh/ruff/pull/26872))

###### Rule changes

- \[`pylint`\] Ignore mutable type updates in `redefined-loop-name` (`PLW2901`) ([#​25733](https://redirect.github.com/astral-sh/ruff/pull/25733))

###### Performance

- Avoid redundant lexer token bookkeeping ([#​26765](https://redirect.github.com/astral-sh/ruff/pull/26765))
- Avoid redundant pending-indentation writes ([#​26774](https://redirect.github.com/astral-sh/ruff/pull/26774))
- Avoid unnecessary identifier lookahead ([#​26525](https://redirect.github.com/astral-sh/ruff/pull/26525))
- Reuse parser scratch buffers ([#​26798](https://redirect.github.com/astral-sh/ruff/pull/26798))

###### Documentation

- Document argfile support ([#​26803](https://redirect.github.com/astral-sh/ruff/pull/26803))
- \[`flake8-datetimez`\] Clarify naming guidance for `datetime.today` (`DTZ002`) ([#​26658](https://redirect.github.com/astral-sh/ruff/pull/26658))
- \[`pycodestyle`\] Document `E731` fix safety ([#​26847](https://redirect.github.com/astral-sh/ruff/pull/26847))

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.15.22)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.4` | `2.5.5` | 2026-07-21 (6 days ago) | 2026-07-29 (in 2 days) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.25.3` | `2.25.4` | 2026-07-26 (a day ago) | 2026-08-03 (in a week) |
| [ruff](https://github.com/astral-sh/ruff) | `0.15.22` | `0.16.0` | 2026-07-23 (4 days ago) | 2026-07-31 (in 4 days) |
| [zizmor](https://github.com/zizmorcore/zizmor) | `1.26.1` | `1.28.0` | 2026-07-21 (6 days ago) | 2026-07-29 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://kdeldycke.github.io/repomatic/workflows.html#sync-tool-versions-updater)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`7b0cf117`](https://github.com/kdeldycke/repomatic/commit/7b0cf11772d4e9611bd9fc730af2ab60ab2a979d)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/7b0cf11772d4e9611bd9fc730af2ab60ab2a979d/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/7b0cf11772d4e9611bd9fc730af2ab60ab2a979d/.github/workflows/autofix.yaml)
- **Run**: [#5047.1](https://github.com/kdeldycke/repomatic/actions/runs/30248017552)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.1.dev0`