### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,7 @@ exclude-newer = "1 week"
 # `exclude-newer`, returning the package to the normal cooldown. repomatic is
 # pinned to git main (no PyPI release to freeze), so it keeps a permanent
 # "0 day" span.
-exclude-newer-package = { click-extra = "2026-07-24T00:00:00Z", repomatic = "0 day" }
+exclude-newer-package = { repomatic = "0 day" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,6 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-click-extra = "2026-07-24T00:00:00Z"
 repomatic = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [[package]]
@@ -285,11 +284,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -1552,11 +1551,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.9"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/80/f1/93422647dd7e461f23d254e6b2bfa687a85b53aeb4903fcdbb74474d4584/soupsieve-2.9.tar.gz", hash = "sha256:acee8417325c5653e1377dc31eccad59eb82cbc65942afe6174c53b3aaad63fc", size = 122122, upload-time = "2026-07-19T01:35:18.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/d6/3185ab5ad1280319b31986898f3206dd7227cd75e293d4dba2a5e6bf27a0/soupsieve-2.9-py3-none-any.whl", hash = "sha256:a2b2c76d67df2382d245409fd71e321a571717e58463efa32ace87dcadac2c12", size = 37387, upload-time = "2026-07-19T01:35:17.106Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]
@@ -1589,14 +1588,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.12.1"
+version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/ae/8ad5e79a0f7beac5e5810b2a8d0a1c6c63c795ba265a81970070abf15f32/sphinx_autodoc_typehints-3.12.1.tar.gz", hash = "sha256:4bbf6f6b907586d3b2a3ae2b23e0f86be939f19a7449e917d304df57ff9674d1", size = 84421, upload-time = "2026-07-03T13:52:09.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/99/e5a23a7bc3f9b6b799dbf72ab3955cdc0b2382803b5d11eaafcc76621662/sphinx_autodoc_typehints-3.13.0.tar.gz", hash = "sha256:59eb4fe26f71ccd7a8f10caadddcb3c3b31df7016f91bda546da2a333bae4e12", size = 85285, upload-time = "2026-07-21T13:10:44.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/a2/d5964523f0c98e39ef608a09f3de23032aa32fbe3e98a262e2112c39f985/sphinx_autodoc_typehints-3.12.1-py3-none-any.whl", hash = "sha256:932472c9cc160e6a0dc34eca13d3d6a9823ed6e6dc505d7c12f6963c983cf8f6", size = 42950, upload-time = "2026-07-03T13:52:07.696Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1c/4b3c9b1a3130b9d717f517351ce8325a62fad7c4f846cc324025c22a43c6/sphinx_autodoc_typehints-3.13.0-py3-none-any.whl", hash = "sha256:d71c388c865f3bedc1f32416febb0f8886b3051a4cd8bd8677e64b8b65c9b475", size = 43440, upload-time = "2026-07-21T13:10:43.793Z" },
 ]
 
 [[package]]
@@ -1811,23 +1810,23 @@ wheels = [
 
 [[package]]
 name = "tomlrt"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/ce/e552a0214ed7f047847c6f1ba581123ff9f5b9e3cb753af21988590d8a04/tomlrt-2.1.0.tar.gz", hash = "sha256:1ae5f35a02d5588ffdc750f80d4a12ca1f85b599cb2805b70f18fad5c2690d5a", size = 350031, upload-time = "2026-07-20T19:39:18.677Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/18/74c541ebf3f34313293b8c66c6fb80d5dde7645859614a22dd634bde3d5d/tomlrt-2.1.1.tar.gz", hash = "sha256:3ca1543a89d816d90df882f6af491a6c064c2437501854e48d2b0036ed5c7a18", size = 352275, upload-time = "2026-07-21T17:11:51.446Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/9c/f15600beb443a412ba616614bdb87742d2760676e8f14f97d9956ff9ed16/tomlrt-2.1.0-py3-none-any.whl", hash = "sha256:a5c6a992596e57e07bb6da432ea6c9cfb23d47817a0a7ff0a9f5997615463473", size = 136563, upload-time = "2026-07-20T19:39:17.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/30/bd195241ebe83ad156a8f62bf0300ca2e0dad2069a540485cf05a079fe1b/tomlrt-2.1.1-py3-none-any.whl", hash = "sha256:c5f8a9998412a734c79545271574682044d16126de113b047477cfd496a044de", size = 137422, upload-time = "2026-07-21T17:11:49.771Z" },
 ]
 
 [[package]]
 name = "types-boltons"
-version = "25.0.0.20260612"
+version = "26.1.0.20260722"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a3/20/0f1d798ee2a11e59e228e8fea0947042bd80123b00fb4fd44673fb51e7db/types_boltons-25.0.0.20260612.tar.gz", hash = "sha256:85c2c90d17cdabe049037f1614af86bc858b214a5a16cc871230777e7cec39c9", size = 22004, upload-time = "2026-06-12T06:22:30.937Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/93/2bf0fb36a9a414b2355358800c189e06e7aa373abb1731dea774acd33d04/types_boltons-26.1.0.20260722.tar.gz", hash = "sha256:9cb5d0497343361a6a834fff91498d607b34ce6f3fe5c8cdc59ba6b78d9c5538", size = 22249, upload-time = "2026-07-22T04:55:57.374Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/31/b8a58cffa7af1ebf6f9116168fcb129b175556794b815176d7a9118bf801/types_boltons-25.0.0.20260612-py3-none-any.whl", hash = "sha256:4ed2f2f3eca268c9b9a1ff4c4bc6c82cc460194d3c0ba6a9113316243f58feca", size = 28378, upload-time = "2026-06-12T06:22:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/0c/b6e4252b5ed8e130f15ccb22c58b5c9dbe32933120acca7b3ba9aa4704b9/types_boltons-26.1.0.20260722-py3-none-any.whl", hash = "sha256:4f129f96dd7f96a670e12ae22d93968151f6c7e9d530e598fd9683a22df02423", size = 28723, upload-time = "2026-07-22T04:55:56.407Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-22`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` → `2026.7.22` | 2026-07-22 (a week ago) |
| [soupsieve](https://pypi.org/project/soupsieve/) | [`2.9` → `2.9.1`](https://github.com/facelessuser/soupsieve/compare/2.9...2.9.1) | 2026-07-21 (a week ago) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.12.1` → `3.13.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.12.1...3.13.0) | 2026-07-21 (a week ago) |
| [tomlrt](https://pypi.org/project/tomlrt/) | [`2.1.0` → `2.1.1`](https://github.com/dimbleby/tomlrt/compare/v2.1.0...v2.1.1) | 2026-07-21 (a week ago) |
| [types-boltons](https://pypi.org/project/types-boltons/) | [`25.0.0.20260612` → `26.1.0.20260722`](https://github.com/python/typeshed/compare/v25.0.0.20260612...v26.1.0.20260722) | 2026-07-22 (a week ago) |

### Release notes

<details>
<summary><code>soupsieve</code></summary>

#### [`2.9.1`](https://github.com/facelessuser/soupsieve/releases/tag/2.9.1)

##### 2.9.1

-   **FIX**: Correct `[attr^=""]`, `[attr$=""]`, and `[attr*=""]` to match nothing when the value is empty, per CSS
    Selectors Level 4 substring matching, which previously matched any element merely having the attribute
    (@​chuenchen309).

</details>

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.13.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.13.0)

<!-- Release notes generated using configuration in .github/release.yaml at 39e9e1c470479e83e21553d074bd03ad9c90645f -->

##### What's Changed
* Replace prettier with mdformat and yamlfmt by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/733
* 👷 ci(python): test against Python 3.15 beta by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/735

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.11.1...3.13.0

</details>

<details>
<summary><code>tomlrt</code></summary>

[Changelog](https://redirect.github.com/dimbleby/tomlrt/blob/main/CHANGELOG.md)

</details>

<details>
<summary><code>types-boltons</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/boltons.md)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [aiohttp](https://pypi.org/project/aiohttp/) | `3.14.2` | `3.14.3` | 2026-07-23 (6 days ago) | 2026-07-30 (in a day) |
| [click-extra](https://pypi.org/project/click-extra/) | `8.5.0` | `8.6.2` | 2026-07-27 (2 days ago) | 2026-08-03 (in 5 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.3.1` | `13.5.1` | 2026-07-27 (2 days ago) | 2026-08-03 (in 5 days) |
| [tomlrt](https://pypi.org/project/tomlrt/) | `2.1.1` | `2.2.0` | 2026-07-24 (5 days ago) | 2026-07-31 (in 2 days) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `26.1.0.20260722` | `26.1.0.20260724` | 2026-07-24 (5 days ago) | 2026-07-31 (in 2 days) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260712` | `0.22.3.20260724` | 2026-07-24 (5 days ago) | 2026-07-31 (in 2 days) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260518` | `6.0.12.20260724` | 2026-07-24 (5 days ago) | 2026-07-31 (in 2 days) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | 🧹 cleared: `8.5.0` | 2026-07-29 (just now) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`f7048779`](https://github.com/kdeldycke/repomatic/commit/f7048779545296ee3d9cb494b8f50c6aed381af8)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/f7048779545296ee3d9cb494b8f50c6aed381af8/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/f7048779545296ee3d9cb494b8f50c6aed381af8/.github/workflows/autofix.yaml)
- **Run**: [#5061.1](https://github.com/kdeldycke/repomatic/actions/runs/30479733495)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.2.dev0`