### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -139,7 +139,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.4.0'
+          uvx --no-progress 'click-extra==8.5.0'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -134,7 +134,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.4.0' prebake all
+        run: uvx --no-progress 'click-extra==8.5.0' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-22` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.4.0` → `8.5.0` | 2026-07-22 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.5.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.5.0)

> [!NOTE]
> `8.5.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.5.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.5.0).

- **Breaking:** Rename the `--show-params` flag to `--params`. Its parameter ID changes from `show_params` to `params`, its environment variable suffix from `_SHOW_PARAMS` to `_PARAMS`, and `click-extra wrap --show-params` becomes `click-extra wrap --params`. `ShowParamsOption` and `@show_params_option` keep their names.
- Add the `click_extra.sphinx.myst_docstrings` Sphinx extension: write Python docstrings in MyST markdown, transparently converted to reST at build time, keeping `sphinx.ext.autodoc` and `sphinx_autodoc_typehints` unmodified. Absorbed from `repomatic.myst_docstrings`.
- Add a `convert-to-myst` subcommand migrating a package's reST docstrings and comments to MyST in place, idempotently: string literals and other runtime code pass through byte-for-byte. Absorbed from `repomatic`, along with the `sphinx-apidoc` stub converter `click_extra.rst_to_myst` and the public `convert_source()`.
- Add a `:mirror:` flag to the `python:render` Sphinx directive: the block's generated Markdown is mirrored into the source `.md` between `<!-- mirror -->` markers, reviewable in raw diffs; builds regenerate it in memory, never writing to the source.
- Extend `click-extra refresh-directives` to also refresh `python:render` `:mirror:` regions, alongside `{matrix}` blocks, by executing each mirror block's Python.
- Add a `start_new_session` option to `run_cli()`: the child leads its own POSIX session and process group, and every kill path signals the whole group, so grandchildren are reaped. Off by default to keep interactive prompts working; no-op on Windows.
- Add a `themes` demo subcommand (`click-extra themes`) printing a sample help screen rendered under every built-in theme, for a quick terminal preview of all palettes.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.5.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.5.0` | `8.6.2` | 2026-07-27 (3 days ago) | 2026-08-04 (in 5 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.3.1` | `13.5.1` | 2026-07-27 (3 days ago) | 2026-08-04 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`a7318aa7`](https://github.com/kdeldycke/repomatic/commit/a7318aa74fb7cfb555ba3f459de2432c93b37ff2)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/a7318aa74fb7cfb555ba3f459de2432c93b37ff2/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/a7318aa74fb7cfb555ba3f459de2432c93b37ff2/.github/workflows/autofix.yaml)
- **Run**: [#5079.1](https://github.com/kdeldycke/repomatic/actions/runs/30563914161)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.0.dev0`