### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -139,7 +139,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.5.0'
+          uvx --no-progress 'click-extra==8.6.0'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -134,7 +134,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.5.0' prebake all
+        run: uvx --no-progress 'click-extra==8.6.0' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-24` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.5.0` → `8.6.0` | 2026-07-24 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.6.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.6.0)

> [!NOTE]
> `8.6.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.6.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.6.0).

- Add `OperationTrail`, the batch-reporting companion of `run_jobs`/`run_lanes`: each operation leaves a persistent `✓`/`✘` line and the batch closes with a timed summary. Adds the `trail_glyph` and `trail_line` helpers.
- Add `column-order` and `row-order` options to `{matrix}` blocks (`newest-first`/`oldest-first`), defaulting both axes to `newest-first` so the most recent compatibility information reads from the upper-left corner.
- Refresh each `python:render` `:mirror:` block through `click-extra refresh-directives` with the source file's directory on `sys.path`, so a block importing a sibling helper module resolves offline as it does at build time.
- Fix `test-suite --command` resolving a venv's symlinked Python interpreter (`.venv/bin/python`) to its base target, silently dropping the venv's installed packages.
- Upload coverage from the once-only test job to Codecov, and move the package-install CLI checks to a dedicated CI job skipped on pull requests.

**Full changelog**: [`v8.5.0...v8.6.0`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.5.0...v8.6.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [npm](https://www.npmjs.com/package/npm) | `12.0.1` | `12.0.2` | 2026-07-29 (3 days ago) | 2026-08-06 (in 5 days) |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` | `8.8.0` | 2026-07-31 (a day ago) | 2026-08-08 (in a week) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.3.1` | `13.5.1` | 2026-07-27 (5 days ago) | 2026-08-04 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`f72d2877`](https://github.com/kdeldycke/repomatic/commit/f72d28776691fb3e00d1fda20fd58254d85b9187)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/f72d28776691fb3e00d1fda20fd58254d85b9187/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/f72d28776691fb3e00d1fda20fd58254d85b9187/.github/workflows/autofix.yaml)
- **Run**: [#5102.1](https://github.com/kdeldycke/repomatic/actions/runs/30700891601)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.1.dev0`