### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_registry.py
+++ b/repomatic/tool_registry.py
@@ -779,27 +779,27 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "698199017fc0b0c865d9a0ca2074102eb1fd0b358fd164595f3960b004fe4b90",
+        ): "be5850727c7ef88516bf0495d345b50bf0e3507c361e912bf24f7329930ea22c",
         (
             LINUX,
             X86_64,
-        ): "4cd66b4a2953197e0e169f24b8a6e5f0fc42b3e852c3f58e562866244f3e11db",
+        ): "3cc9a0c3fa26ac26a89e8a3b203c010c9ae88e36f69a2679e79981f267ce9d57",
         (
             MACOS,
             AARCH64,
-        ): "1250bb41a0409cf6c3133fc47819237eb61251624297f87158d2bed3ec123c3c",
+        ): "5dba813a5ee1bd2749b9f3ee020e1f42d3fbd8fda7ed1d5d4df23fdb87e76579",
         (
             MACOS,
             X86_64,
-        ): "b3dfae5422dbd86272bb8ed40afec66670ea7754531d8fbcbae7e445e5430387",
+        ): "02f773b007e5ebe6b40f35e8999bd9c24eaa8dd5231dcab610bc1a17ef17b1b6",
         (
             WINDOWS,
             AARCH64,
-        ): "95bf56ccd99e090adf43127328e456b63422eb201471746b1d21c7aa33349005",
+        ): "2796c61fd757fe2ef760d645b4047746aa40ad543cd712672e6558ce4ff60b88",
         (
             WINDOWS,
             X86_64,
-        ): "49d1ef3925d31b2f08c00b76786621bf4603fdb4c3bfeff1aa2cd4d98de3a27c",
+        ): "47b7c8f59181870782dbeb26bfa45a51229a277ffd458f5cf852dc96dfd3999c",
     },
     "gitleaks": {
         (
@@ -922,7 +922,7 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
-    "biome": "2.5.4",
+    "biome": "2.5.6",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
     "lychee": "0.24.2",
@@ -1035,7 +1035,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "biome": ToolSpec(
         name="biome",
         display_name="Biome",
-        version="2.5.4",
+        version="2.5.6",
         source_url="https://github.com/biomejs/biome",
         tag_pattern=r"^@biomejs/biome@(?P<version>.+)$",
         config_docs_url="https://biomejs.dev/reference/configuration/",
@@ -1098,7 +1098,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "bump-my-version": ToolSpec(
         name="bump-my-version",
-        version="1.4.1",
+        version="1.5.0",
         reads_pyproject=True,
         source_url="https://github.com/callowayproject/bump-my-version",
         config_docs_url="https://callowayproject.github.io/bump-my-version/reference/configuration/",
@@ -1310,7 +1310,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
             "mdformat_footnote==0.1.3",
             "mdformat-front-matters==2.0.0",
             "mdformat-gfm==1.0.0",
-            "mdformat_gfm_alerts==2.0.0",
+            "mdformat_gfm_alerts==2.1.0",
             "mdformat_myst==0.3.0",
             "mdformat-pelican==1.0.0",
             "mdformat_pyproject==0.1.1",
@@ -1420,7 +1420,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "pyproject-fmt": ToolSpec(
         name="pyproject-fmt",
-        version="2.25.3",
+        version="2.26.0",
         source_url="https://github.com/tox-dev/pyproject-fmt",
         config_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
         cli_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
@@ -1448,7 +1448,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "ruff": ToolSpec(
         name="ruff",
         display_name="Ruff",
-        version="0.15.22",
+        version="0.16.1",
         source_url="https://github.com/astral-sh/ruff",
         config_docs_url="https://docs.astral.sh/ruff/configuration/",
         cli_docs_url="https://docs.astral.sh/ruff/configuration/#command-line-interface",
@@ -1620,7 +1620,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "zizmor": ToolSpec(
         name="zizmor",
-        version="1.26.1",
+        version="1.28.0",
         source_url="https://github.com/zizmorcore/zizmor",
         config_docs_url="https://docs.zizmor.sh/configuration/",
         cli_docs_url="https://docs.zizmor.sh/usage/",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-30` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.4` → `2.5.6` | 2026-07-28 (a week ago) |
| [bump-my-version](https://github.com/callowayproject/bump-my-version) | `1.4.1` → `1.5.0` | 2026-07-27 (a week ago) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.25.3` → `2.26.0` | 2026-07-27 (a week ago) |
| [ruff](https://github.com/astral-sh/ruff) | `0.15.22` → `0.16.1` | 2026-07-30 (a week ago) |
| [zizmor](https://github.com/zizmorcore/zizmor) | `1.26.1` → `1.28.0` | 2026-07-21 (a month ago) |
| [mdformat_gfm_alerts](https://pypi.org/project/mdformat_gfm_alerts/) | `2.0.0` → `2.1.0` | 2026-07-26 (a week ago) |

### Release notes

<details>
<summary><code>biome</code></summary>

#### [`@biomejs/biome@2.5.5`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.5)

##### 2.5.5

###### Patch Changes

- [#​10972](https://redirect.github.com/biomejs/biome/pull/10972) [`ab8c21b`](https://redirect.github.com/biomejs/biome/commit/ab8c21b35e81708276e4283a4a0ff86ea815e345) Thanks [@​ematipico](https://redirect.github.com/ematipico)! - Fixed [`useExhaustiveSwitchCases`](https://biomejs.dev/linter/rules/use-exhaustive-switch-cases/) for unions of bigint literals. The rule now reports missing bigint cases and compares bigint literals by value, including binary, octal, hexadecimal, and separator-containing spellings. For example, this switch now reports the missing `2n` case:

  ```ts
  declare const value: 1n | 2n;
  switch (value) {
    case 1n:
      break;
  }
  ```

- [#​10972](https://redirect.github.com/biomejs/biome/pull/10972) [`ab8c21b`](https://redirect.github.com/biomejs/biome/commit/ab8c21b35e81708276e4283a4a0ff86ea815e345) Thanks [@​ematipico](https://redirect.github.com/ematipico)! - Fixed false positives in [`noBaseToString`](https://biomejs.dev/linter/rules/no-base-to-string/) and [`useNullishCoalescing`](https://biomejs.dev/linter/rules/use-nullish-coalescing/) when member, stringification, or nullish inference cannot complete. These rules now suppress diagnostics instead of reporting from partial type information. For example, neither expression is reported when a recursive type cannot be fully resolved:

  ```ts
  type Recursive = Recursive;
  declare const value: Recursive;

  String(value);
  value || "fallback";
  ```

- [#​10977](https://redirect.github.com/biomejs/biome/pull/10977) [`0bf7486`](https://redirect.github.com/biomejs/biome/commit/0bf748653e488d0b959d39847641438cdb28188b) Thanks [@​ematipico](https://redirect.github.com/ematipico)! - Fixed [#​10922](https://redirect.github.com/biomejs/biome/issues/10922): the action [`useSortedAttributes`](https://biomejs.dev/assist/actions/use-sorted-attributes/) no longer triggers for HTML instructions.

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.5)

#### [`@biomejs/biome@2.5.6`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.6)

##### 2.5.6

###### Patch Changes

- [#​11035](https://redirect.github.com/biomejs/biome/pull/11035) [`0e4b03b`](https://redirect.github.com/biomejs/biome/commit/0e4b03be71b32120c6326e58e046260bcf5d3231) Thanks [@​ematipico](https://redirect.github.com/ematipico)! - Fixed a performance regression in [`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/) that caused type inference to run repeatedly while linting a file.

- [#​11043](https://redirect.github.com/biomejs/biome/pull/11043) [`22ec076`](https://redirect.github.com/biomejs/biome/commit/22ec076462d4590ea7c95f7693b69040c32a38aa) Thanks [@​denbezrukov](https://redirect.github.com/denbezrukov)! - Fixed CSS formatting for multiline function arguments preceded by comments:

  ```diff
   .example {
     value: outer(
       1,
       /* comment */
       nested(
  -      first,
  -      second
  -    )
  +        first,
  +        second
  +      )
     );
   }
  ```

- [#​11007](https://redirect.github.com/biomejs/biome/pull/11007) [`c9acb25`](https://redirect.github.com/biomejs/biome/commit/c9acb25acbce7a6f632b5041ec546a604aea4343) Thanks [@​BTF-Kabir-2020](https://redirect.github.com/BTF-Kabir-2020)! - Fixed [#​9195](https://redirect.github.com/biomejs/biome/issues/9195): [`useHookAtTopLevel`](https://biomejs.dev/linter/rules/use-hook-at-top-level/) no longer reports hooks in named `forwardRef` components that receive a `ref` parameter.

- [#​10152](https://redirect.github.com/biomejs/biome/pull/10152) [`50a9bd8`](https://redirect.github.com/biomejs/biome/commit/50a9bd84df852de305e94a91fb57f6b3b1378187) Thanks [@​Zelys-DFKH](https://redirect.github.com/Zelys-DFKH)! - Fixed [#​10131](https://redirect.github.com/biomejs/biome/issues/10131): Biome now correctly parses curried arrow functions in ternary consequents when the inner arrow's parameters use a destructuring pattern, e.g. `cond ? (x) => ({ a, b }) => body : alt`.

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.6)

</details>

<details>
<summary><code>bump-my-version</code></summary>

#### [`1.5.0`](https://github.com/callowayproject/bump-my-version/releases/tag/1.5.0)

[Compare the full difference.](https://redirect.github.com/callowayproject/bump-my-version/compare/1.4.1...1.5.0)

##### Other

- Adjust logging levels and add warning for missing configuration files in tests. [4420d9e](https://redirect.github.com/callowayproject/bump-my-version/commit/4420d9e760e2019334717c78adb5009e0ff01c51)

  Fixes #​421

- Bump the github-actions group across 1 directory with 2 updates. [0944890](https://redirect.github.com/callowayproject/bump-my-version/commit/0944890f919e405baea5cec96352877a94959d34)

  Bumps the github-actions group with 2 updates in the / directory: [actions/checkout](https://redirect.github.com/actions/checkout) and [actions/setup-python](https://redirect.github.com/actions/setup-python).

  Updates `actions/checkout` from 6 to 7

  - [Release notes](https://redirect.github.com/actions/checkout/releases)
  - [Changelog](https://redirect.github.com/actions/checkout/blob/main/CHANGELOG.md)
  - [Commits](https://redirect.github.com/actions/checkout/compare/v6...v7)

  Updates `actions/setup-python` from 6 to 7

  - [Release notes](https://redirect.github.com/actions/setup-python/releases)
  - [Commits](https://redirect.github.com/actions/setup-python/compare/v6...v7)

  ______________________________________________________________________

  **updated-dependencies:** - dependency-name: actions/checkout
  dependency-version: '7'
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: github-actions

  **signed-off-by:** dependabot[bot] <support@github.com>

- [pre-commit.ci] pre-commit autoupdate. [39a2478](https://redirect.github.com/callowayproject/bump-my-version/commit/39a2478832714e4dd65a53ba7c85721da3c8d033)

  **updates:** - [github.com/astral-sh/ruff-pre-commit: v0.15.17 → v0.15.22](https://redirect.github.com/astral-sh/ruff-pre-commit/compare/v0.15.17...v0.15.22)

##### Updates

... [Full release notes](https://github.com/callowayproject/bump-my-version/releases/tag/1.5.0)

</details>

<details>
<summary><code>pyproject-fmt</code></summary>

#### [`v2.25.4`](https://github.com/tox-dev/pyproject-fmt/releases/tag/v2.25.4)

<!-- Release notes generated using configuration in .github/release.yaml at v2.25.4 -->

##### What's Changed
* Replace prettier with mdformat and yamlfmt by @​gaborbernat in https://redirect.github.com/tox-dev/pyproject-fmt/pull/352
* Use Python 3.15 by @​gaborbernat in https://redirect.github.com/tox-dev/pyproject-fmt/pull/354

**Full Changelog**: https://redirect.github.com/tox-dev/pyproject-fmt/compare/v2.25.3...v2.25.4

#### [`v2.26.0`](https://github.com/tox-dev/pyproject-fmt/releases/tag/v2.26.0)

<!-- Release notes generated using configuration in .github/release.yaml at v2.26.0 -->

**Full Changelog**: https://redirect.github.com/tox-dev/pyproject-fmt/compare/v2.25.4...v2.26.0

</details>

<details>
<summary><code>ruff</code></summary>

#### [`0.16.0`](https://github.com/astral-sh/ruff/releases/tag/0.16.0)

##### Release Notes

Released on 2026-07-23.

Check out the [blog post](https://astral.sh/blog/ruff-v0.16.0) for a migration guide and overview of the changes!

###### Breaking changes

- Ruff now enables a much larger set of rules by default (413, up from 59). See the blog post for more details and the new [Default Rules](https://docs.astral.sh/ruff/default-rules/) page for a full listing of the enabled rules. Note that this is primarily an expansion, but 18 of the more opinionated pycodestyle (`E`) and pyflakes (`F`) rules have been removed from the default set: `E401`, `E402`, `E701`, `E702`, `E703`, `E711`, `E712`, `E713`, `E714`, `E721`, `E731`, `E741`, `E742`, `E743`, `F403`, `F405`, `F406`, and `F722`.

- Ruff can now format Python code blocks in Markdown files and will do this by default. See the [documentation](https://docs.astral.sh/ruff/formatter/#markdown-code-formatting) for more details.

- Ruff now supports `ruff: ignore` comments at the ends of lines, like `noqa` comments, or on the line preceding a diagnostic. For example, these both suppress an [`unused-import`](https://docs.astral.sh/ruff/rules/unused-import/) (`F401`) diagnostic:

    ```py
    import math  # ruff: ignore[F401]

    # ruff: ignore[F401]
    import os
    ```

- Fixes are now shown in `check` and `format --check` output:

    ````console
    ❯ ruff format --check .
    unformatted: File would be reformatted
     --> try.md:1:1
      |
    1 | ```python
      - import   math
    2 + import math
    3 | ```
      |

    1 file would be reformatted
    ````

    This example also shows off the Markdown formatting.

- `format --check` now supports the same output formats as the linter, including the `github` and `gitlab` outputs for rendering annotations in CI:

    ```console
    ❯ ruff format --check --output-format github .

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.16.0)

#### [`0.16.1`](https://github.com/astral-sh/ruff/releases/tag/0.16.1)

##### Release Notes

Released on 2026-07-30.

###### Preview features

- Add an option to opt out of human-readable names ([#​27160](https://redirect.github.com/astral-sh/ruff/pull/27160))
- \[`flake8-pytest-style`\] Make fixes safe by default and unsafe only when comments are present (`PT018`) ([#​27201](https://redirect.github.com/astral-sh/ruff/pull/27201))
- \[`pyupgrade`\] Skip fix when a defaulted `TypeVar` precedes a non-defaulted one (`UP040`, `UP046`, `UP047`) ([#​27133](https://redirect.github.com/astral-sh/ruff/pull/27133))
- \[`ruff`\] Fix false positive with unpacked arguments (`RUF065`) ([#​26959](https://redirect.github.com/astral-sh/ruff/pull/26959))

###### Bug fixes

- Bump `gen-lsp-types` to gracefully handle unknown enumeration values in LSP messages ([#​27230](https://redirect.github.com/astral-sh/ruff/pull/27230))
- \[`flake8-bugbear`\] Mark `range` as immutable (`B008`) ([#​27247](https://redirect.github.com/astral-sh/ruff/pull/27247))
- \[`flake8-comprehensions`\] NFKC-normalize keyword names in `C408` fix ([#​26813](https://redirect.github.com/astral-sh/ruff/pull/26813))
- \[`flake8-return`\] Fix false positive when variable is read in `finally` clause (`RET504`) ([#​25441](https://redirect.github.com/astral-sh/ruff/pull/25441))
- \[`pydocstyle`\] Skip section detection inside RST directive bodies (`D214`, `D405`, `D413`) ([#​23635](https://redirect.github.com/astral-sh/ruff/pull/23635))
- \[`refurb`\] Parenthesize `yield` arguments in the `FURB192` fix ([#​27192](https://redirect.github.com/astral-sh/ruff/pull/27192))

###### Rule changes

- \[`flake8-pytest-style`\] Mark `PT022` fixes as unsafe ([#​26440](https://redirect.github.com/astral-sh/ruff/pull/26440))
- \[`refurb`\] Mark fixes that remove unknown separators as unsafe (`FURB105`) ([#​27200](https://redirect.github.com/astral-sh/ruff/pull/27200))

###### Server

- Fix indexing of excluded nested Ruff workspaces ([#​27303](https://redirect.github.com/astral-sh/ruff/pull/27303))

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.16.1)

</details>

<details>
<summary><code>zizmor</code></summary>

#### [`v1.27.0`](https://github.com/zizmorcore/zizmor/releases/tag/v1.27.0)

##### New Features 🌈[🔗](https://docs.zizmor.sh/release-notes/#new-feartures)

- zizmor now has experimental support for workflows that specify parallel steps. See [Usage - Parallel steps](https://docs.zizmor.sh/usage/#parallel-steps) for more information ([#​2153](https://redirect.github.com/zizmorcore/zizmor/issues/2153))
Enhancements 🌱[🔗](https://docs.zizmor.sh/release-notes/#enhancements)

- zizmor's handling of paths is now more consistent, particularly when run on Windows ([#​2163](https://redirect.github.com/zizmorcore/zizmor/issues/2163))

- zizmor now emits a helpful warning when being run in implicit offline mode ([#​2180](https://redirect.github.com/zizmorcore/zizmor/issues/2180))

##### Bug Fixes 🐛[🔗](https://docs.zizmor.sh/release-notes/#bug-fixes)

- Fixed a bug where the [secrets-outside-env](https://docs.zizmor.sh/audits/#secrets-outside-env) audit would not honor ignore comments within the same job scope ([#​2157](https://redirect.github.com/zizmorcore/zizmor/issues/2157))

- Fixed a bug where the [ref-version-mismatch](https://docs.zizmor.sh/audits/#ref-version-mismatch) audit would not honor ignore comments within the same steps scope ([#​2177](https://redirect.github.com/zizmorcore/zizmor/issues/2177))

- Fixed a bug where `--collect=[MODE]` was not correctly handled when auditing remote inputs ([#​2185](https://redirect.github.com/zizmorcore/zizmor/issues/2185))

#### [`v1.28.0`](https://github.com/zizmorcore/zizmor/releases/tag/v1.28.0)

##### Security 🔒[🔗](https://docs.zizmor.sh/release-notes/#security)

- v1.27.0 contained a logging defect that would print any configured GitHub credentials as part of zizmor's cleartext logging. No versions other than v1.27.0 were affected. See [GHSA-f42p-wjw5-97qh](https://redirect.github.com/zizmorcore/zizmor/security/advisories/GHSA-f42p-wjw5-97qh) for full information.

    Many thanks to [@​shaanmajid](https://redirect.github.com/shaanmajid) for finding and reporting this vulnerability.

##### Enhancements 🌱[🔗](https://docs.zizmor.sh/release-notes/#enhancements)

- The JSON (v1) output format now includes metadata for each finding's fixes, if the finding has fixes ([#​2186](https://redirect.github.com/zizmorcore/zizmor/issues/2186))

- The [dependabot-cooldown](https://docs.zizmor.sh/audits/#dependabot-cooldown) audit is now aware of GitHub's new three-day default cooldown ([#​2193](https://redirect.github.com/zizmorcore/zizmor/issues/2193))

- sbt is now recognized as a package-ecosystem in dependabot.yml ([#​2211](https://redirect.github.com/zizmorcore/zizmor/issues/2211))

##### Bug Fixes 🐛[🔗](https://docs.zizmor.sh/release-notes/#bug-fixes)

- Fixed a bug where the [template-injection](https://docs.zizmor.sh/audits/#template-injection) audit would incorrectly flag `steps.*.outcome` and `steps.*.conclusion` as injection risks in the default persona ([#​2199](https://redirect.github.com/zizmorcore/zizmor/issues/2199))

- Fixed a bug where the [github-env](https://docs.zizmor.sh/audits/#github-env) audit would incorrectly flag some printf calls as exploitable ([#​2201](https://redirect.github.com/zizmorcore/zizmor/issues/2201))

- Fixed a bug where zizmor would produce a misleading and confusing error message when asked to audit an ambiguous remote input ([#​2205](https://redirect.github.com/zizmorcore/zizmor/issues/2205))

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.6` | `2.5.7` | 2026-08-04 (3 days ago) | 2026-08-12 (in 5 days) |
| [bump-my-version](https://github.com/callowayproject/bump-my-version) | `1.5.0` | `1.5.1` | 2026-08-06 (a day ago) | 2026-08-14 (in a week) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.26.0` | `2.27.0` | 2026-08-03 (4 days ago) | 2026-08-11 (in 4 days) |
| [typos](https://github.com/crate-ci/typos) | `1.48.0` | `1.49.0` | 2026-08-03 (4 days ago) | 2026-08-11 (in 4 days) |
| [zizmor](https://github.com/zizmorcore/zizmor) | `1.28.0` | `1.29.0` | 2026-08-01 (6 days ago) | 2026-08-09 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://kdeldycke.github.io/repomatic/workflows.html#sync-tool-versions-sync-tool-versions)
- **Trigger**: `workflow_dispatch`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`9f4e0095`](https://github.com/kdeldycke/repomatic/commit/9f4e0095bf6bf7870566788d7b4b39101457f38c)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/9f4e0095bf6bf7870566788d7b4b39101457f38c/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/9f4e0095bf6bf7870566788d7b4b39101457f38c/.github/workflows/self-maintenance.yaml)
- **Run**: [#1.1](https://github.com/kdeldycke/repomatic/actions/runs/31153275979)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.5.0.dev0`