### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ exclude-newer = "1 week"
 # `exclude-newer`, returning the package to the normal cooldown. repomatic is
 # pinned to git main (no PyPI release to freeze), so it keeps a permanent
 # "0 day" span.
-exclude-newer-package = { click-extra = "2026-08-02T00:00:00Z", extra-platforms = "2026-07-28T00:00:00Z", repomatic = "0 day" }
+exclude-newer-package = { click-extra = "2026-08-02T00:00:00Z", repomatic = "0 day" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,6 @@ exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
 click-extra = "2026-08-02T00:00:00Z"
-extra-platforms = "2026-07-28T00:00:00Z"
 repomatic = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [[package]]


### PR DESCRIPTION
## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.8.0` | 2026-08-07 (just now) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | 🧹 cleared: `13.5.1` | 2026-08-03 |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.8.0` | `8.8.1` | 2026-08-02 (5 days ago) | 2026-08-09 (in 2 days) |
| [coverage](https://pypi.org/project/coverage/) | `7.15.2` | `7.15.4` | 2026-08-06 (a day ago) | 2026-08-13 (in 6 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.1` | `13.6.0` | 2026-08-03 (4 days ago) | 2026-08-10 (in 3 days) |
| [packaging](https://pypi.org/project/packaging/) | `26.2` | `26.3` | 2026-08-04 (3 days ago) | 2026-08-11 (in 4 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9.1` | `2.9.2` | 2026-08-07 (just now) | 2026-08-14 (in a week) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.0` | `3.13.2` | 2026-08-03 (4 days ago) | 2026-08-10 (in 3 days) |
| [tomlrt](https://pypi.org/project/tomlrt/) | `2.2.0` | `2.2.1` | 2026-08-04 (3 days ago) | 2026-08-11 (in 4 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`6820d3ca`](https://github.com/kdeldycke/repomatic/commit/6820d3ca55eec24ac4fc2750b78d9d201bbb4c68)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/6820d3ca55eec24ac4fc2750b78d9d201bbb4c68/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/6820d3ca55eec24ac4fc2750b78d9d201bbb4c68/.github/workflows/autofix.yaml)
- **Run**: [#5126.1](https://github.com/kdeldycke/repomatic/actions/runs/31150672777)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.5.0.dev0`