### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -139,7 +139,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.6.0'
+          uvx --no-progress 'click-extra==8.7.0'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -135,7 +135,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.6.0' prebake all
+        run: uvx --no-progress 'click-extra==8.7.0' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true

--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -62,4 +62,4 @@ jobs:
     steps:
       - uses: crazy-max/ghaction-dump-context@4d9eeaf15dd59aa4346919ea84a84ccf514b4db8 # v3.1.0
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      - run: uvx --no-progress 'extra-platforms==13.3.1'
+      - run: uvx --no-progress 'extra-platforms==13.5.1'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -218,7 +218,7 @@ jobs:
         env:
           NPM_MIN_RELEASE_AGE: ${{ fromJSON(needs.metadata.outputs.metadata).npm_min_release_age_days }}
         run: > # zizmor: ignore[adhoc-packages]
-          npm install npm@12.0.1 --global --ignore-scripts --no-progress
+          npm install npm@12.0.2 --global --ignore-scripts --no-progress
           --no-update-notifier --no-fund --no-audit
           --min-release-age="$NPM_MIN_RELEASE_AGE"
       - name: Run awesome-lint


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-30` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` → `8.7.0` | 2026-07-30 (a week ago) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.3.1` → `13.5.1` | 2026-07-27 (a week ago) |
| [npm](https://www.npmjs.com/package/npm) | `12.0.1` → `12.0.2` | 2026-07-29 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.6.1`](https://github.com/kdeldycke/click-extra/releases/tag/v8.6.1)

> [!NOTE]
> `8.6.1` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.6.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.6.1).

- **Deprecated:** `ClickExtraConfig`, `PrebakeConfig` and `TestSuiteConfig` resolve again from the top-level `click_extra` namespace, warning and redirecting to `click_extra.config`; removed in `9.0.0`.
- **Deprecated:** The `click_extra.test_plan` module and the top-level `TestPlanConfig`, `parse_test_plan`, `run_test_plan` and `DEFAULT_TEST_PLAN` names warn and resolve to their `test_suite` replacements; removed in `9.0.0`.
- **Deprecated:** `prebake_dunder`, `prebake_version` and `discover_package_init_files` resolve again from `click_extra.version`, warning and redirecting to `click_extra.prebake`; removed in `9.0.0`.
- **Deprecated:** Importing `INDENT`, `PROMPT`, `args_cleanup` or `format_cli_prompt` from `click_extra.testing` now warns and redirects to `click_extra.execution`; removed in `9.0.0`.
- Ship the test suite and the docs and CI files it reads in the PyPI sdist, so downstream packagers can build and test without a Git checkout.
- Add a `[tool.setuptools]` shim so builds that fall back to setuptools still bundle the `themes.toml` and `py.typed` data files.
- Fix the source line reported in `click:run` variable-conflict errors when a MyST directive's body ends in blank lines.
- Fix the MkDocs test tree erroring instead of self-skipping when `mkdocs-click` is absent but `mkdocs` and `pymdown-extensions` are present.

**Full changelog**: [`v8.6.0...v8.6.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.6.0...v8.6.1)

#### [`v8.6.2`](https://github.com/kdeldycke/click-extra/releases/tag/v8.6.2)

> [!NOTE]
> `8.6.2` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.6.2/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.6.2).

- Treat an unreaped zombie as a dead process in the `run_cli` process-group teardown tests, so they pass in a build sandbox with no init to reap orphans (like Alpine's `abuild` container).

**Full changelog**: [`v8.6.1...v8.6.2`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.6.1...v8.6.2)

#### [`v8.6.3`](https://github.com/kdeldycke/click-extra/releases/tag/v8.6.3)

> [!NOTE]
> `8.6.3` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.6.3/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.6.3).

- Stop importing the test tooling at package import time: the `click_extra.testing` and `click_extra.test_suite` exports now resolve lazily, keeping Click's debugger stack out of importing programs and compiled binaries.
- Scrub the submodule objects star imports leaked into the package namespace: foreign modules like `click_extra.core` and `click_extra.termui` no longer hand out Click's un-enhanced classes or shadow the `globals` builtin.
- Pin `[tool.repomatic]` `nuitka.nofollow-imports` to its bare `["tkinter"]` default, ahead of the repomatic release introducing the setting.
- Fix the `myst_docstrings` MyST-to-reST converter mispairing inline-code backticks and emitting reST literals with illegal edge whitespace from padded code spans.

**Full changelog**: [`v8.6.2...v8.6.3`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.6.2...v8.6.3)

#### [`v8.7.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.7.0)

> [!NOTE]
> `8.7.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.7.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.7.0).

- Add a `<!-- mirror-src -->` comment form of `python:render` `:mirror:`: the generator Python lives inside an HTML comment, so its output renders on GitHub and PyPI while the generator stays invisible.
- Export `update_blocks`, `marker_res`, and a new `replace_region` helper from `click_extra.sphinx` for downstream self-updating documentation scripts.
- Accept kebab-case keys in configuration files: `dummy-flag` and `dummy_flag` both address the `--dummy-flag` option, the last spelling winning on collision with a warning.
- Scope the configuration strict check and merge to the app's own section, ignoring other tools' sections in shared files like `pyproject.toml`.
- Honor legacy `fallback_sections` when merging configuration values into `default_map`, not only in the schema path.
- Forward `config_strict` and additive `excluded_params` from `@command`/`@group` to the default `--config` option.
- Load the configuration file before `--params` and `--export-config` render, so both reflect it whatever the order of the flags.
- Export parameters without a value in `--export-config`: empty lists for multi-value options, `null` in YAML and JSON, commented-out keys in TOML.
- Render `--export-config` keys in kebab-case, the canonical spelling for configuration files, matching the CLI flags.
- Exclude `--validate-config` from configuration files, like the other self-referential config options.
- Reword the unknown-configuration-key error, and report parameters blocked from configuration files as not allowed instead of unknown.
- Fix `DO_NOT_TRACK` handling: a truthy value now forces `--telemetry` off; it previously fed the boolean flag verbatim and enabled telemetry.
- Add an executables download table and a release-verification section to the installation guide.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.7.0)

</details>

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.4.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.4.0)

> [!NOTE]
> `13.4.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.4.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.4.0).

- Add `write_fake_executable()` to `extra_platforms.pytest`: a fake command for tests that drive a real subprocess, runnable even in a `/bin/sh`-less build sandbox.
- Add `@skip_hermetic_build` / `@unless_hermetic_build` as aliases of the Guix-build decorators, covering any `HOME=/homeless-shelter` build sandbox (Guix, Nixpkgs, ...).
- Ship the test suite in the PyPI sdist so downstream packagers can build and test from it; a plain `pytest` run no longer needs `pytest-cov` or `pytest-xdist`.
- Drop the `repomatic` documentation dependency: the MyST-docstrings Sphinx extension now comes from `click-extra[sphinx]>=8.5`.
- Add a "Downstream packaging" guide for distribution packagers.
- Extend the Sphinx cross-reference conformance tests to MyST-style roles in Python docstrings, previously never collected.

**Full changelog**: [`v13.3.1...v13.4.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.3.1...v13.4.0)

#### [`v13.5.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.5.0)

> [!NOTE]
> `13.5.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.5.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.5.0).

- Rename the `GUIX_BUILD` CI trait to `HERMETIC_BUILD`. `GUIX_BUILD`, `is_guix_build()` and the `skip_guix_build`/`unless_guix_build` decorators still resolve to their `HERMETIC_BUILD` counterparts with a `DeprecationWarning`, and will be removed in `14.0.0`.

**Full changelog**: [`v13.4.0...v13.5.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.4.0...v13.5.0)

#### [`v13.5.1`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.5.1)

> [!NOTE]
> `13.5.1` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.5.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.5.1).

- Skip `test_github_runner_detection` unless `EXTRA_PLATFORMS_TEST_MATRIX` is set, instead of whenever GitHub CI is detected, so downstream packagers building the test suite inside GitHub Actions no longer fail on the absent matrix variable.

**Full changelog**: [`v13.5.0...v13.5.1`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.5.0...v13.5.1)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.7.0` | `8.8.1` | 2026-08-02 (5 days ago) | 2026-08-10 (in 3 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.1` | `13.6.0` | 2026-08-03 (4 days ago) | 2026-08-11 (in 4 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`3ae1d4b9`](https://github.com/kdeldycke/repomatic/commit/3ae1d4b9fbf98730319252dda6634dbaef294657)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/3ae1d4b9fbf98730319252dda6634dbaef294657/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/3ae1d4b9fbf98730319252dda6634dbaef294657/.github/workflows/autofix.yaml)
- **Run**: [#5124.1](https://github.com/kdeldycke/repomatic/actions/runs/31149182292)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.5.0.dev0`