### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -199,7 +199,7 @@ jobs:
         if: >-
           github.ref == 'refs/heads/main'
           && fromJSON(needs.metadata.outputs.metadata).release_commits_matrix
-        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: ${{ matrix.bin_name }}
       - name: Install gh in container
@@ -450,7 +450,7 @@ jobs:
       # Same provenance chain as the compiled binaries and the extra-assets job.
       - name: Generate tarball attestation
         id: attest-manpages
-        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: >-
             ${{
@@ -535,7 +535,7 @@ jobs:
           done
       - name: Generate assets attestation
         id: attest-assets
-        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: release-assets/*
       - name: Verify assets attestation


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-30` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/attest](https://github.com/actions/attest) | [`v4.2.0` → `v4.2.1`](https://github.com/actions/attest/compare/v4.2.0...v4.2.1) | 2026-07-29 (a week ago) |

### Release notes

<details>
<summary><code>actions/attest</code></summary>

#### [`v4.2.1`](https://github.com/actions/attest/releases/tag/v4.2.1)

##### What's Changed
* Bump tar from 7.5.17 to 7.5.21 by @​dependabot[bot] in https://redirect.github.com/actions/attest/pull/459
* fix: strip OCI image tag when pushing attestation to registry by @​bdehamer in https://redirect.github.com/actions/attest/pull/464

**Full Changelog**: https://redirect.github.com/actions/attest/compare/v4.2.0...v4.2.1

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Action | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [actions/attest](https://github.com/actions/attest) | `4.2.1` | `4.2.2` | 2026-08-04 (3 days ago) | 2026-08-12 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`0f9935c3`](https://github.com/kdeldycke/repomatic/commit/0f9935c31f7622cca5b5114acca5e0e459108ef3)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/0f9935c31f7622cca5b5114acca5e0e459108ef3/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/0f9935c31f7622cca5b5114acca5e0e459108ef3/.github/workflows/autofix.yaml)
- **Run**: [#5120.1](https://github.com/kdeldycke/repomatic/actions/runs/31147928694)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.5.0.dev0`