### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_registry.py
+++ b/repomatic/tool_registry.py
@@ -904,27 +904,27 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909",
+        ): "73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5",
         (
             LINUX,
             X86_64,
-        ): "83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60",
+        ): "a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112",
         (
             MACOS,
             AARCH64,
-        ): "f23a0c37d963aacc3bed703ccbd59b41c5ca22101fab7f00eb2b7cad23aba463",
+        ): "a58b8fd77b417a38f47a0b54d1370c59b0fcdb324ccc9ca002b0998f7c4c999e",
         (
             MACOS,
             X86_64,
-        ): "4bd449df9ad639391bc62b8032546f0fe9edcd8526e06682a4f88abd8c5d163c",
+        ): "63298c998cc2a924c9e254c6af6a1caad6ece281122687a91f079bc0a462700e",
         (
             WINDOWS,
             AARCH64,
-        ): "c517e0b32c98a4ba90ac95af8d12cc3ac55781ab4ab72f9a91ce3de0541d2b09",
+        ): "3e2d4a166da4ee5020c592737b65eec0e724946d5d5b962f5fe59d99116dc4bf",
         (
             WINDOWS,
             X86_64,
-        ): "c2d6acc935cd2f00e2144d7e036d5cd82e6b6bd5594e8c75aa75ef2a4ed6aac3",
+        ): "35d7fe05c4dd1411ffda1e73dfc7c6f44b75c936ca51fa6595c657fdc0350cec",
     },
     "gitleaks": {
         (
@@ -1070,7 +1070,7 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
     "biome": "2.5.6",
-    "gh": "2.96.0",
+    "gh": "2.97.0",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
     "lychee": "0.24.2",
@@ -1275,7 +1275,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "gh": ToolSpec(
         name="gh",
         display_name="GitHub CLI",
-        version="2.96.0",
+        version="2.97.0",
         source_url="https://github.com/cli/cli",
         cli_docs_url="https://cli.github.com/manual/",
         binary=BinarySpec(


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-01` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [gh](https://github.com/cli/cli) | `2.96.0` → `2.97.0` | 2026-07-31 (a week ago) |

### Release notes

<details>
<summary><code>gh</code></summary>

#### [`v2.97.0`](https://github.com/cli/cli/releases/tag/v2.97.0)

##### Security

Four security vulnerabilities have been identified, and fixed, in this release. Users are advised to update gh to version `v2.97.0` as soon as possible.

Several commands (including `gh gist view`, `gh api`, `gh pr diff`, `gh release download --output -`, `gh codespace logs`, `gh skills preview`, and `gh agent-task view`/`create`) printed externally controlled content without neutralizing terminal escape sequences, allowing escape sequence injection into a user's terminal.

See https://redirect.github.com/cli/cli/security/advisories/GHSA-3m3g-3wcr-px46 for more information.

Some request URLs were built without escaping their variable path components, so a value containing URL path metacharacters could alter the request path and cause `gh` to address a different resource than intended.

See https://redirect.github.com/cli/cli/security/advisories/GHSA-4fjg-2h4q-fwg3 for more information.

`gh auth status` (without `--show-token`) could print a portion of the authentication token in plaintext for token types whose format contains an underscore after the prefix, such as `github_pat_*`, `ghs_*`, and `ghu_*`.

See https://redirect.github.com/cli/cli/security/advisories/GHSA-cg6r-mpgc-h9mm for more information.

`gh attestation verify` built the certificate matcher from `--signer-repo` and `--signer-workflow` without escaping regex metacharacters, so a lookalike repository or workflow name could satisfy a matcher intended for a trusted signer and bypass attestation verification. 

See https://redirect.github.com/cli/cli/security/advisories/GHSA-mm27-mwq9-fr5g for more information.


##### Address project fields and items by name in `gh project`

`gh project item-edit` and `gh project item-list` can now reference project fields and single-select options by name:

```shell
# Set an item's field by name
gh project item-edit 1 --owner monalisa --url <url> --field "Status" --value "In Progress"


... [Full release notes](https://github.com/cli/cli/releases/tag/v2.97.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.6` | `2.5.7` | 2026-08-04 (4 days ago) | 2026-08-11 (in 3 days) |
| [bump-my-version](https://github.com/callowayproject/bump-my-version) | `1.5.0` | `1.5.1` | 2026-08-06 (2 days ago) | 2026-08-13 (in 5 days) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.26.0` | `2.27.0` | 2026-08-03 (5 days ago) | 2026-08-10 (in 2 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.1` | `0.16.2` | 2026-08-07 (a day ago) | 2026-08-14 (in 6 days) |
| [typos](https://github.com/crate-ci/typos) | `1.48.0` | `1.49.0` | 2026-08-03 (5 days ago) | 2026-08-10 (in 2 days) |
| [zizmor](https://github.com/zizmorcore/zizmor) | `1.28.0` | `1.29.0` | 2026-08-01 (a week ago) | 2026-08-08 (just now) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://kdeldycke.github.io/repomatic/workflows.html#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`89bfe183`](https://github.com/kdeldycke/repomatic/commit/89bfe1836aef1ac5f4713339d824c17f0f76f9ff)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/89bfe1836aef1ac5f4713339d824c17f0f76f9ff/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/89bfe1836aef1ac5f4713339d824c17f0f76f9ff/.github/workflows/self-maintenance.yaml)
- **Run**: [#2.1](https://github.com/kdeldycke/repomatic/actions/runs/31243851439)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.5.1.dev0`