### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,9 @@
 
 ## [`7.6.0` (2026-08-08)](https://github.com/kdeldycke/repomatic/compare/v7.5.0...v7.6.0)
 
+> [!NOTE]
+> `7.6.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.6.0/) and [🐙 GitHub](https://github.com/kdeldycke/repomatic/releases/tag/v7.6.0).
+
 - **Breaking:** the `labels` component is now ephemeral: `labels.toml` and the two labeller YAMLs are staged only when named explicitly (`repomatic init labels`). A repository that committed them sees them reported as excluded files on disk, removable with `init --delete-excluded`.
 - New `fix-awesome-toc` command deletes the table-of-contents entries awesome-lint forbids from `readme.md` and every `readme.{lang}.md` beside it, matching translated sections by position rather than by their English name.
 - The bundled skills and agents are now published as a Claude Code plugin: `/plugin marketplace add kdeldycke/repomatic` then `/plugin install repomatic@kdeldycke`. Needs Claude Code 2.1.224 or later. Addresses [#2378](https://github.com/kdeldycke/repomatic/issues/2378).


### PR DESCRIPTION
## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`abandoned-versions`](https://kdeldycke.github.io/repomatic/configuration.html#abandoned-versions)
- [`changelog.archive-location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-archive-location)
- [`changelog.location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-location)
- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`fix-changelog`](https://kdeldycke.github.io/repomatic/workflows.html#fix-changelog-fix-changelog)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`c88db425`](https://github.com/kdeldycke/repomatic/commit/c88db425694bf95fcf81becb8613520220d49abb)
- **Job**: [`fix-changelog`](https://github.com/kdeldycke/repomatic/blob/c88db425694bf95fcf81becb8613520220d49abb/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/c88db425694bf95fcf81becb8613520220d49abb/.github/workflows/changelog.yaml)
- **Run**: [#4824.1](https://github.com/kdeldycke/repomatic/actions/runs/31262756763)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.6.1.dev0`