### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_registry.py
+++ b/repomatic/tool_registry.py
@@ -1958,7 +1958,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "zizmor": ToolSpec(
         name="zizmor",
-        version="1.28.0",
+        version="1.29.0",
         source_url="https://github.com/zizmorcore/zizmor",
         config_docs_url="https://docs.zizmor.sh/configuration/",
         cli_docs_url="https://docs.zizmor.sh/usage/",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-02` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [zizmor](https://github.com/zizmorcore/zizmor) | `1.28.0` → `1.29.0` | 2026-08-01 (a week ago) |

### Release notes

<details>
<summary><code>zizmor</code></summary>

#### [`v1.29.0`](https://github.com/zizmorcore/zizmor/releases/tag/v1.29.0)

##### New Features 🌈[🔗](https://docs.zizmor.sh/release-notes/#new-features)

- zizmor now has **experimental** support for auditing pre-commit inputs, meaning both pre-commit configuration and hook definitions ([#​2209](https://redirect.github.com/zizmorcore/zizmor/issues/2209))

- New audit: [insecure-url-scheme](https://docs.zizmor.sh/audits/#insecure-url-scheme) detects usages of insecure (i.e. plaintext) protocols when making network requests. The initial version of this audit is limited to pre-commit inputs only ([#​2228](https://redirect.github.com/zizmorcore/zizmor/issues/2228))

- zizmor now supports GitHub's "self-repository" reference syntax for local actions, e.g. `uses: $/foo/bar` instead of a manual checkout and `uses: ./foo/bar` ([#​2248](https://redirect.github.com/zizmorcore/zizmor/issues/2248))

##### Changes ⚠️[🔗](https://docs.zizmor.sh/release-notes/#changes)

- The [unpinned-uses](https://docs.zizmor.sh/audits/#unpinned-uses) and [unpinned-images](https://docs.zizmor.sh/audits/#unpinned-images) audits have been separated more cleanly: [unpinned-uses](https://docs.zizmor.sh/audits/#unpinned-uses) is now principally responsible for Git-style `uses:` clauses, whereas [unpinned-images](https://docs.zizmor.sh/audits/#unpinned-images) is now responsible for `docker://`-style `uses:` clauses (in addition to already checking other image references) ([#​2222](https://redirect.github.com/zizmorcore/zizmor/issues/2222))

##### Removals 🌅[🔗](https://docs.zizmor.sh/release-notes/#removals)

- `--collect=workflows-only` and `--collect=actions-only` have been fully removed. Use `--collect=workflows` and `--collect=actions` for the replacement behavior ([#​2242](https://redirect.github.com/zizmorcore/zizmor/issues/2242))

##### Bug Fixes 🐛[🔗](https://docs.zizmor.sh/release-notes/#bug-fixes)


... [Full release notes](https://github.com/zizmorcore/zizmor/releases/tag/v1.29.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.6` | `2.5.7` | 2026-08-04 (5 days ago) | 2026-08-11 (in 2 days) |
| [bump-my-version](https://github.com/callowayproject/bump-my-version) | `1.5.0` | `1.5.1` | 2026-08-06 (3 days ago) | 2026-08-13 (in 4 days) |
| [oxipng](https://github.com/shssoichiro/oxipng) | `10.1.1` | `10.2.0` | 2026-08-09 (just now) | 2026-08-16 (in a week) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.26.0` | `2.27.0` | 2026-08-03 (6 days ago) | 2026-08-10 (in a day) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.1` | `0.16.2` | 2026-08-07 (2 days ago) | 2026-08-14 (in 5 days) |
| [typos](https://github.com/crate-ci/typos) | `1.48.0` | `1.49.0` | 2026-08-03 (6 days ago) | 2026-08-10 (in a day) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://kdeldycke.github.io/repomatic/workflows.html#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`926fcb9a`](https://github.com/kdeldycke/repomatic/commit/926fcb9a0395be85e0d9c2d93b4f457542a7a5a8)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/926fcb9a0395be85e0d9c2d93b4f457542a7a5a8/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/926fcb9a0395be85e0d9c2d93b4f457542a7a5a8/.github/workflows/self-maintenance.yaml)
- **Run**: [#3.1](https://github.com/kdeldycke/repomatic/actions/runs/31298959243)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.7.0.dev0`