### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "8.8.0"
+version = "8.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -405,9 +405,9 @@ dependencies = [
     { name = "wcmatch" },
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/b4/f373ae3338a2364411ec78d2c891d528958acd9c45cb3165099adf864fc5/click_extra-8.8.0.tar.gz", hash = "sha256:e65ffaf55b93cc5b984d01b1e200918c44b93f0c810f27114ac9ea62eda9d871", size = 1262759, upload-time = "2026-07-31T17:54:59.264Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/f2/ab33d5d978f4ceb1b52eb3e4ee0538aa197768913d411380a7b318e45e91/click_extra-8.8.1.tar.gz", hash = "sha256:fc67535bbc186ac608b04f1da3dd1c442903567f08a12f484af89a894653f796", size = 1263359, upload-time = "2026-08-02T06:09:18.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/84/aa9bf87f4a662a867671bbc10d798feef7221037d63b1173b3b0a425f88c/click_extra-8.8.0-py3-none-any.whl", hash = "sha256:747a6b1bfe1bd15a6b28cbbb4134fd0a680c3a3846366ab7089ddf663cbea101", size = 442056, upload-time = "2026-07-31T17:54:57.587Z" },
+    { url = "https://files.pythonhosted.org/packages/32/e8/79d8d14891d3b8a69be97da3383e2da69832d55e84a8a9ca1196d653d7c7/click_extra-8.8.1-py3-none-any.whl", hash = "sha256:30b6fbf2ebbce57aa2ec1a24e8f6ec6ffc91e7488d84d8fd14d9ac1c27c6e257", size = 442054, upload-time = "2026-08-02T06:09:16.972Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-02`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | [`8.8.0` → `8.8.1`](https://github.com/kdeldycke/click-extra/compare/v8.8.0...v8.8.1) | 2026-08-02 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.8.1`](https://github.com/kdeldycke/click-extra/releases/tag/v8.8.1)

> [!NOTE]
> `8.8.1` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.8.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.8.1).

- Widen the `[tool.uv]` `required-version` to `>=0.11.15` and the `[build-system]` `uv-build` floor to `>=0.8`, dropping the previous `<0.13` upper cap.

**Full changelog**: [`v8.8.0...v8.8.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.8.0...v8.8.1)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [coverage](https://pypi.org/project/coverage/) | `7.15.2` | `7.15.4` | 2026-08-06 (3 days ago) | 2026-08-13 (in 4 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.2` | `13.6.0` | 2026-08-03 (6 days ago) | 2026-08-10 (in a day) |
| [packaging](https://pypi.org/project/packaging/) | `26.2` | `26.3` | 2026-08-04 (5 days ago) | 2026-08-11 (in 2 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9.1` | `2.9.2` | 2026-08-07 (2 days ago) | 2026-08-14 (in 5 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.0` | `3.13.2` | 2026-08-03 (6 days ago) | 2026-08-10 (in a day) |
| [tomlrt](https://pypi.org/project/tomlrt/) | `2.2.0` | `2.2.1` | 2026-08-04 (5 days ago) | 2026-08-11 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`9c7e1831`](https://github.com/kdeldycke/repomatic/commit/9c7e183136c8e0d9912f0d63d09dec1864c5ffe3)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/9c7e183136c8e0d9912f0d63d09dec1864c5ffe3/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/9c7e183136c8e0d9912f0d63d09dec1864c5ffe3/.github/workflows/autofix.yaml)
- **Run**: [#5187.1](https://github.com/kdeldycke/repomatic/actions/runs/31298977458)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.7.0.dev0`