### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -77,4 +77,4 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.12.1"
-      - run: uvx --no-progress 'extra-platforms==13.5.1'
+      - run: uvx --no-progress 'extra-platforms==13.5.2'


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-02` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.1` → `13.5.2` | 2026-08-01 (a week ago) |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.5.2`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.5.2)

> [!NOTE]
> `13.5.2` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.5.2/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.5.2).

- Reorganize the installation page: quick start first, then `uvx` try-it tabs, install methods, the Python compatibility matrix and the dependency graph.
- Register MyST heading anchors so in-page documentation links resolve at build time.
- Render the CLI `--help` screen live in the documentation so its option list can't drift from the code.

**Full changelog**: [`v13.5.1...v13.5.2`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.5.1...v13.5.2)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.8.0` | `8.8.1` | 2026-08-02 (a week ago) | 2026-08-09 (just now) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.2` | `13.6.0` | 2026-08-03 (6 days ago) | 2026-08-10 (in a day) |
| [uv](https://pypi.org/project/uv/) | `0.12.1` | `0.12.3` | 2026-08-07 (2 days ago) | 2026-08-14 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`9c7e1831`](https://github.com/kdeldycke/repomatic/commit/9c7e183136c8e0d9912f0d63d09dec1864c5ffe3)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/9c7e183136c8e0d9912f0d63d09dec1864c5ffe3/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/9c7e183136c8e0d9912f0d63d09dec1864c5ffe3/.github/workflows/autofix.yaml)
- **Run**: [#5187.1](https://github.com/kdeldycke/repomatic/actions/runs/31298977458)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.7.0.dev0`