### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -583,11 +583,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.5.2"
+version = "13.5.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/85/fca1871c5a7662b54ae07798e4d4890825640ee158d87df5bcfb487c5e07/extra_platforms-13.5.2.tar.gz", hash = "sha256:435510ff55885caa4199fb7f698b3a74ca00e47c0e9e3352c6b9855b790efabd", size = 460276, upload-time = "2026-08-01T13:22:17.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/76/18a6be3aed79db31f15bed87c1a1271e4d1a46a613d4247fb23fa4635f19/extra_platforms-13.5.3.tar.gz", hash = "sha256:3e362487b1b6ce6e01fa28a912684d07da53b06d9cfdb6e8af1558e501a62f45", size = 460359, upload-time = "2026-08-02T07:31:52.7Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/24/0d0603aeb895469057e909951f0dba40577965d4dbbb0100f22ecbb370c7/extra_platforms-13.5.2-py3-none-any.whl", hash = "sha256:b79e5d5b002822022f33f8ebb9a60987bd7757dfdc2ce92cfc7e8cd3134b8883", size = 97116, upload-time = "2026-08-01T13:22:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/53/ad7a950786f427a77b304e9b88858f23983a277ad643d67ec336ab99e9d0/extra_platforms-13.5.3-py3-none-any.whl", hash = "sha256:7d7ed23284619c1e1f9b355b045bb1c225645525876ef8f85518ffda229ae573", size = 97116, upload-time = "2026-08-02T07:31:51.392Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-02`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`13.5.2` → `13.5.3`](https://github.com/kdeldycke/extra-platforms/compare/v13.5.2...v13.5.3) | 2026-08-02 (a week ago) |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.5.3`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.5.3)

> [!NOTE]
> `13.5.3` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.5.3/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.5.3).

- Sync CI tooling, workflow pins and dependency floors with the latest repomatic release; no functional changes to the package.

**Full changelog**: [`v13.5.2...v13.5.3`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.5.2...v13.5.3)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [coverage](https://pypi.org/project/coverage/) | `7.15.2` | `7.15.4` | 2026-08-06 (3 days ago) | 2026-08-13 (in 4 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.3` | `13.6.0` | 2026-08-03 (6 days ago) | 2026-08-10 (in a day) |
| [packaging](https://pypi.org/project/packaging/) | `26.2` | `26.3` | 2026-08-04 (5 days ago) | 2026-08-11 (in 2 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9.1` | `2.9.2` | 2026-08-07 (2 days ago) | 2026-08-14 (in 5 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.0` | `3.13.2` | 2026-08-03 (6 days ago) | 2026-08-10 (in a day) |
| [tomlrt](https://pypi.org/project/tomlrt/) | `2.2.0` | `2.2.1` | 2026-08-04 (5 days ago) | 2026-08-11 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`ff37930c`](https://github.com/kdeldycke/repomatic/commit/ff37930c7f4ce64278c9f75a6e8212bb208b4ed1)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/ff37930c7f4ce64278c9f75a6e8212bb208b4ed1/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/ff37930c7f4ce64278c9f75a6e8212bb208b4ed1/.github/workflows/autofix.yaml)
- **Run**: [#5197.1](https://github.com/kdeldycke/repomatic/actions/runs/31303268358)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.7.1.dev0`