### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -167,7 +167,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.8.0'
+          uvx --no-progress 'click-extra==8.8.1'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -217,7 +217,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.8.0' prebake all
+        run: uvx --no-progress 'click-extra==8.8.1' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true

--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -78,4 +78,4 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.12.1"
-      - run: uvx --no-progress 'extra-platforms==13.5.2'
+      - run: uvx --no-progress 'extra-platforms==13.5.3'


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-03` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.8.0` → `8.8.1` | 2026-08-02 (a week ago) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.2` → `13.5.3` | 2026-08-02 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.8.1`](https://github.com/kdeldycke/click-extra/releases/tag/v8.8.1)

> [!NOTE]
> `8.8.1` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.8.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.8.1).

- Widen the `[tool.uv]` `required-version` to `>=0.11.15` and the `[build-system]` `uv-build` floor to `>=0.8`, dropping the previous `<0.13` upper cap.

**Full changelog**: [`v8.8.0...v8.8.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.8.0...v8.8.1)

</details>

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.5.3`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.5.3)

> [!NOTE]
> `13.5.3` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.5.3/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.5.3).

- Sync CI tooling, workflow pins and dependency floors with the latest repomatic release; no functional changes to the package.

**Full changelog**: [`v13.5.2...v13.5.3`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.5.2...v13.5.3)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.3` | `13.6.0` | 2026-08-03 (a week ago) | 2026-08-10 (just now) |
| [uv](https://pypi.org/project/uv/) | `0.12.1` | `0.12.3` | 2026-08-07 (3 days ago) | 2026-08-14 (in 4 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`5fd4b31b`](https://github.com/kdeldycke/repomatic/commit/5fd4b31b540498df0c486e169add854d0f788a69)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/5fd4b31b540498df0c486e169add854d0f788a69/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/5fd4b31b540498df0c486e169add854d0f788a69/.github/workflows/autofix.yaml)
- **Run**: [#5222.1](https://github.com/kdeldycke/repomatic/actions/runs/31377953669)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.9.0.dev0`