### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -82,4 +82,4 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.12.1"
-      - run: uvx --no-progress 'extra-platforms==13.5.3'
+      - run: uvx --no-progress 'extra-platforms==13.6.0'


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-04` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.3` → `13.6.0` | 2026-08-03 (a week ago) |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.6.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.6.0)

> [!NOTE]
> `13.6.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.6.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.6.0).

- Add AlmaLinux platform detection: `ALMALINUX` / `is_almalinux()` (via `ID=almalinux` in `os-release`).
- Add EndeavourOS platform detection: `ENDEAVOUROS` / `is_endeavouros()` (via `ID=endeavouros` in `os-release`). Closes [#​658](https://redirect.github.com/kdeldycke/extra-platforms/issues/658).
- Unrecognized shell, terminal, CI and agent warnings now report the environment variables (`SHELL`, `TERM`, `CI`, `LLM`, ...) each is detected from, not just the architecture/platform primitives.

**Full changelog**: [`v13.5.3...v13.6.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.5.3...v13.6.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.1` | `0.12.3` | 2026-08-07 (4 days ago) | 2026-08-14 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`118e17f6`](https://github.com/kdeldycke/repomatic/commit/118e17f6b43e8ad29132ea1dbcb56e0c80a0bfab)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/118e17f6b43e8ad29132ea1dbcb56e0c80a0bfab/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/118e17f6b43e8ad29132ea1dbcb56e0c80a0bfab/.github/workflows/autofix.yaml)
- **Run**: [#5254.1](https://github.com/kdeldycke/repomatic/actions/runs/31492858315)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.10.0.dev0`