### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_registry.py
+++ b/repomatic/tool_registry.py
@@ -1124,23 +1124,23 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "2960ae07bc1ffe19e4895e4359394dd349c9c31de78aac3a124b6e4aeb206698",
+        ): "85c8b87b22a0fb1da130cd4d495e0beba7f1225eb580933184509e146ec4c509",
         (
             LINUX,
             X86_64,
-        ): "72a930c9a94fc3914aa56835c5b859c892a797d40c1c42638b98d93f16ff519c",
+        ): "48bd2d58e02ce713b8c0f1aa239e68ee4f7d8c551013135806e6aed3938d9e10",
         (
             MACOS,
             AARCH64,
-        ): "7dcaf386ec255995dcbaf629641f961574b7e8785203921115eab75cbf1ca107",
+        ): "8c0e7bd40b2b60c0b0cfe9f74dd814b4d4385c956ce86860f7da9e62d91fdc73",
         (
             MACOS,
             X86_64,
-        ): "f4335c255db3d57374484e0e96505c8910c0e2fa6d8813b15de529c98f93b1a9",
+        ): "4cecbf653a9fc45f023abf57f4e2e2f6b138c2d2387b09289beacdd3f0ea7bfd",
         (
             WINDOWS,
             X86_64,
-        ): "ce018a2352da7c1b23bd2684019ee279d2080dc063087020e80c1247d11b0743",
+        ): "06d3a1b71c282e021671070696a72696d5c60ea485b47dc4f8f1fbcf90144d02",
     },
 }
 """Tool name to platform-keyed SHA-256 hex digest mapping.
@@ -1160,7 +1160,7 @@ VERSIONS: dict[str, str] = {
     "lychee": "0.24.2",
     "oxipng": "10.1.1",
     "shfmt": "3.13.1",
-    "typos": "1.48.0",
+    "typos": "1.49.0",
 }
 """Tool name to the version each checksum set was computed for.
 
@@ -1761,7 +1761,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "pyproject-fmt": ToolSpec(
         name="pyproject-fmt",
-        version="2.26.0",
+        version="2.27.0",
         source_url="https://github.com/tox-dev/pyproject-fmt",
         config_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
         cli_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
@@ -1862,7 +1862,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "typos": ToolSpec(
         name="typos",
-        version="1.48.0",
+        version="1.49.0",
         source_url="https://github.com/crate-ci/typos",
         config_docs_url="https://github.com/crate-ci/typos/blob/master/docs/reference.md",
         cli_docs_url="https://github.com/crate-ci/typos/blob/master/docs/reference.md",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-04` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.26.0` → `2.27.0` | 2026-08-03 (a week ago) |
| [typos](https://github.com/crate-ci/typos) | `1.48.0` → `1.49.0` | 2026-08-03 (a week ago) |

### Release notes

<details>
<summary><code>pyproject-fmt</code></summary>

#### [`v2.27.0`](https://github.com/tox-dev/pyproject-fmt/releases/tag/v2.27.0)

<!-- Release notes generated using configuration in .github/release.yaml at v2.27.0 -->

**Full Changelog**: https://redirect.github.com/tox-dev/pyproject-fmt/compare/v2.26.0...v2.27.0

</details>

<details>
<summary><code>typos</code></summary>

#### [`v1.49.0`](https://github.com/crate-ci/typos/releases/tag/v1.49.0)

##### [1.49.0] - 2026-08-03

###### Features

- Updated the dictionary with the [July 2026](https://redirect.github.com/crate-ci/typos/issues/1573) changes

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.6` | `2.5.7` | 2026-08-04 (a week ago) | 2026-08-11 (just now) |
| [bump-my-version](https://github.com/callowayproject/bump-my-version) | `1.5.0` | `1.5.1` | 2026-08-06 (5 days ago) | 2026-08-13 (in 2 days) |
| [oxipng](https://github.com/shssoichiro/oxipng) | `10.1.1` | `10.2.0` | 2026-08-09 (2 days ago) | 2026-08-16 (in 5 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.1` | `0.16.2` | 2026-08-07 (4 days ago) | 2026-08-14 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://kdeldycke.github.io/repomatic/workflows.html#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`eb87c887`](https://github.com/kdeldycke/repomatic/commit/eb87c88732998b01b87305f331a837ca50691488)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/eb87c88732998b01b87305f331a837ca50691488/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/eb87c88732998b01b87305f331a837ca50691488/.github/workflows/self-maintenance.yaml)
- **Run**: [#5.1](https://github.com/kdeldycke/repomatic/actions/runs/31465628556)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.10.0.dev0`