### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1041,11 +1041,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "26.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-05`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [packaging](https://pypi.org/project/packaging/) | [`26.2` → `26.3`](https://github.com/pypa/packaging/compare/26.2...26.3) | 2026-08-04 (a week ago) |

### Release notes

<details>
<summary><code>packaging</code></summary>

#### [`26.3`](https://github.com/pypa/packaging/releases/tag/26.3)

<!-- Release notes generated using configuration in .github/release.yml at 26.3 -->

##### What's Changed

###### Features

* Add a public `VersionRange` API and `SpecifierSet.to_range()`, representing the versions a specifier set accepts as an interval set that supports intersection, union, difference, complement, set relations, membership tests, and filtering. `VersionRange.to_specifier_set()` converts a range back to a `SpecifierSet` where a PEP 440 form exists. ([#​1267](https://redirect.github.com/pypa/packaging/pull/1267), [#​1270](https://redirect.github.com/pypa/packaging/pull/1270), [#​1298](https://redirect.github.com/pypa/packaging/pull/1298))
* PEP 808: accept `Metadata-Version: 2.6`. ([#​1194](https://redirect.github.com/pypa/packaging/pull/1194))
* Add a `limit` argument to `parse_tag()` for compressed tag sets. ([#​1220](https://redirect.github.com/pypa/packaging/issues/1220))
* Add a `prefer_sdist_predicate` argument to `Pylock.select()` to prefer source distributions over wheels for selected packages. ([#​1334](https://redirect.github.com/pypa/packaging/pull/1334))
* Add `pure_python_tags()` to generate the pure-Python tags for a Python version without touching the running platform. ([#​1346](https://redirect.github.com/pypa/packaging/pull/1346))
* Add `SpecifierSet.is_subset()`, `SpecifierSet.is_superset()`, and `SpecifierSet.is_disjoint()`, which compare the versions two specifier sets accept. ([#​1313](https://redirect.github.com/pypa/packaging/pull/1313))

###### Behavior adaptations

* Drop support for Python 3.8; packaging now requires Python 3.9 or later. ([#​1157](https://redirect.github.com/pypa/packaging/pull/1157))
* Prefer native `linux_*` platform tags over `manylinux` and `musllinux` tags on Linux. ([#​160](https://redirect.github.com/pypa/packaging/issues/160))

###### Fixes for versions and specifiers

... [Full release notes](https://github.com/pypa/packaging/releases/tag/26.3)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [coverage](https://pypi.org/project/coverage/) | `7.15.3` | `7.15.4` | 2026-08-06 (6 days ago) | 2026-08-13 (in a day) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9.1` | `2.9.2` | 2026-08-07 (5 days ago) | 2026-08-14 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`6671c83f`](https://github.com/kdeldycke/repomatic/commit/6671c83f70658a610e9d91106e5fbd1038e00713)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/6671c83f70658a610e9d91106e5fbd1038e00713/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/6671c83f70658a610e9d91106e5fbd1038e00713/.github/workflows/autofix.yaml)
- **Run**: [#5264.1](https://github.com/kdeldycke/repomatic/actions/runs/31566531556)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.10.0.dev0`