### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_registry.py
+++ b/repomatic/tool_registry.py
@@ -962,27 +962,27 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "be5850727c7ef88516bf0495d345b50bf0e3507c361e912bf24f7329930ea22c",
+        ): "27490d47af66420788b634afb48db23b588f272c8a284ba3daf706a5faa640ab",
         (
             LINUX,
             X86_64,
-        ): "3cc9a0c3fa26ac26a89e8a3b203c010c9ae88e36f69a2679e79981f267ce9d57",
+        ): "7b5045d6d34f055df8ffe1bf3077164e6f6a24c45a41497d628a5e86d0e12fe7",
         (
             MACOS,
             AARCH64,
-        ): "5dba813a5ee1bd2749b9f3ee020e1f42d3fbd8fda7ed1d5d4df23fdb87e76579",
+        ): "f71fe80909d2f70f1e051320f5ba9dfd553bc5ef3bacef5cdee1b00ee96a285c",
         (
             MACOS,
             X86_64,
-        ): "02f773b007e5ebe6b40f35e8999bd9c24eaa8dd5231dcab610bc1a17ef17b1b6",
+        ): "887431b79e45758e05d94a89111af72b28e5d6545c92480ecac9247d8bacb321",
         (
             WINDOWS,
             AARCH64,
-        ): "2796c61fd757fe2ef760d645b4047746aa40ad543cd712672e6558ce4ff60b88",
+        ): "655cc1f2ecf3719f79c9def7f2d824bb2a451fcd1d738d43468b12dd66620fd5",
         (
             WINDOWS,
             X86_64,
-        ): "47b7c8f59181870782dbeb26bfa45a51229a277ffd458f5cf852dc96dfd3999c",
+        ): "62adea0ea523f04cc5c074b2bb00e748b97252023aede03196e1bf4aacf80a9c",
     },
     "gh": {
         (
@@ -1153,7 +1153,7 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
-    "biome": "2.5.6",
+    "biome": "2.5.7",
     "gh": "2.97.0",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
@@ -1268,7 +1268,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "biome": ToolSpec(
         name="biome",
         display_name="Biome",
-        version="2.5.6",
+        version="2.5.7",
         source_url="https://github.com/biomejs/biome",
         tag_pattern=r"^@biomejs/biome@(?P<version>.+)$",
         config_docs_url="https://biomejs.dev/reference/configuration/",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-05` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.6` → `2.5.7` | 2026-08-04 (a week ago) |

### Release notes

<details>
<summary><code>biome</code></summary>

#### [`@biomejs/biome@2.5.7`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.7)

##### 2.5.7

###### Patch Changes

- [#​10822](https://redirect.github.com/biomejs/biome/pull/10822) [`c171b3b`](https://redirect.github.com/biomejs/biome/commit/c171b3bd513d49c35b66cdc74a5de0ca0766b6ef) Thanks [@​pkallos](https://redirect.github.com/pkallos)! - Added the option `ignoreIfStatements` to [useNullishCoalescing](https://biomejs.dev/linter/rules/use-nullish-coalescing/). Biome now flags `if` statements that only assign to a nullish variable (such as `if (!a) { a = b }`) and can rewrite them to `??=`. When enabled, Biome ignores those `if` statements.

- [#​11136](https://redirect.github.com/biomejs/biome/pull/11136) [`e63354c`](https://redirect.github.com/biomejs/biome/commit/e63354cf280783fa6380951342bdacc3fd55e681) Thanks [@​AkashNaickar](https://redirect.github.com/AkashNaickar)! - Added a new nursery rule [`noExtendNative`](https://biomejs.dev/linter/rules/no-extend-native/), which reports extending the prototype of a built-in object.

- [#​10094](https://redirect.github.com/biomejs/biome/pull/10094) [`e007143`](https://redirect.github.com/biomejs/biome/commit/e00714360807115210e549caca0f235431ca9a8a) Thanks [@​THEjacob1000](https://redirect.github.com/THEjacob1000)! - Added the nursery rule [`noTailwindArbitraryValue`](https://biomejs.dev/linter/rules/no-tailwind-arbitrary-value/). Biome now reports Tailwind CSS arbitrary values such as `w-[400px]`, including in HTML/JSX class attributes, configured utility functions, and tagged templates.

- [#​11184](https://redirect.github.com/biomejs/biome/pull/11184) [`135f476`](https://redirect.github.com/biomejs/biome/commit/135f476de8b853f9dc2ff2679ea3525432e66e8e) Thanks [@​subotac](https://redirect.github.com/subotac)! - Fixed [#​11176](https://redirect.github.com/biomejs/biome/issues/11176): `noUnknownPseudoClass` now recognizes Vue's `:deep()` pseudo-class inside `.vue` style blocks.

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.7)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.7` | `2.5.8` | 2026-08-11 (a day ago) | 2026-08-18 (in 6 days) |
| [bump-my-version](https://github.com/callowayproject/bump-my-version) | `1.5.0` | `1.5.1` | 2026-08-06 (6 days ago) | 2026-08-13 (in a day) |
| [oxipng](https://github.com/shssoichiro/oxipng) | `10.1.1` | `10.2.0` | 2026-08-09 (3 days ago) | 2026-08-16 (in 4 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.1` | `0.16.2` | 2026-08-07 (5 days ago) | 2026-08-14 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://kdeldycke.github.io/repomatic/workflows.html#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`c37586ba`](https://github.com/kdeldycke/repomatic/commit/c37586ba4f878c40d5239ebd10233bfc183b0c27)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/c37586ba4f878c40d5239ebd10233bfc183b0c27/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/c37586ba4f878c40d5239ebd10233bfc183b0c27/.github/workflows/self-maintenance.yaml)
- **Run**: [#6.1](https://github.com/kdeldycke/repomatic/actions/runs/31572042006)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.10.1.dev0`