### PR TITLE
[changelog] Bump minor version to `v7.11.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`7.10.1.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v7.10.0...main)
+## [`7.11.0.dev0` (unreleased)](https://github.com/kdeldycke/repomatic/compare/v7.10.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [ "uv-build>=0.8" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "repomatic"
-version = "7.10.1.dev0"
+version = "7.11.0.dev0"
 description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 readme = "readme.md"
 keywords = [
@@ -145,7 +145,7 @@ dependencies = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/repomatic/blob/main/changelog.md"
 urls.Documentation = "https://kdeldycke.github.io/repomatic"
-urls.Download = "https://github.com/kdeldycke/repomatic/releases/tag/v7.10.1.dev0"
+urls.Download = "https://github.com/kdeldycke/repomatic/releases/tag/v7.11.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/repomatic"
 urls.Issues = "https://github.com/kdeldycke/repomatic/issues"
@@ -250,7 +250,7 @@ copyright = "Kevin Deldycke <kevin@deldycke.com> and contributors. Distributed u
 file-description = "🏭 Automate repository maintenance, releases, and CI/CD workflows"
 # Numeric only: Nuitka rejects PEP 440 .devN suffixes. Kept in sync with the
 # package version by the dedicated [tool.bumpversion] rule that strips the suffix.
-file-version = "7.10.1"
+file-version = "7.11.0"
 include-data-dir = [
   "repomatic/data/awesome_template=repomatic/data/awesome_template",
   "repomatic/data/skills=repomatic/data/skills",
@@ -269,7 +269,7 @@ include-package-data = [ "click_extra" ]
 linux-icon = "docs/assets/icon.png"
 macos-app-icon = "docs/assets/icon.icns"
 product-name = "Repomatic"
-product-version = "7.10.1"
+product-version = "7.11.0"
 windows-icon-from-ico = "docs/assets/icon.ico"
 
 [tool.ruff]
@@ -407,7 +407,7 @@ report.fail_under = 80
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "7.10.1.dev0"
+current_version = "7.11.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/repomatic/__init__.py
+++ b/repomatic/__init__.py
@@ -17,5 +17,5 @@
 
 from __future__ import annotations
 
-__version__ = "7.10.1.dev0"
+__version__ = "7.11.0.dev0"
 __git_tag_sha__ = ""

--- a/uv.lock
+++ b/uv.lock
@@ -1407,7 +1407,7 @@ wheels = [
 
 [[package]]
 name = "repomatic"
-version = "7.10.1.dev0"
+version = "7.11.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

## To bump version to `v7.11.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`bump-version`](https://kdeldycke.github.io/repomatic/workflows.html#bump-version-bump-version)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`c37586ba`](https://github.com/kdeldycke/repomatic/commit/c37586ba4f878c40d5239ebd10233bfc183b0c27)
- **Job**: [`bump-version`](https://github.com/kdeldycke/repomatic/blob/c37586ba4f878c40d5239ebd10233bfc183b0c27/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/c37586ba4f878c40d5239ebd10233bfc183b0c27/.github/workflows/changelog.yaml)
- **Run**: [#5016.1](https://github.com/kdeldycke/repomatic/actions/runs/31574670157)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.0.dev0`