### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,9 @@
 
 ## [`7.11.0` (2026-08-13)](https://github.com/kdeldycke/repomatic/compare/v7.10.0...v7.11.0)
 
+> [!NOTE]
+> `7.11.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.11.0/) and [🐙 GitHub](https://github.com/kdeldycke/repomatic/releases/tag/v7.11.0).
+
 - **Breaking:** `labels.content-rules` and `labels.file-rules` are now tables mapping each label to its patterns, like `"📚 docs" = ["docs/**"]`. The array-of-tables form and its `actions/labeler` v5 matcher schema are gone; an un-migrated config is ignored with a warning.
 - **Breaking:** the `file-labeller` and `content-labeller` jobs merged into a single `apply-labels` job. Update any required check or `needs:` edge naming them.
 - **Breaking:** `repomatic init` and `repomatic workflow lint` take `--upstream-repo` for the upstream toolkit; `--repo` now means the `owner/name` slug everywhere, including on `sync-labels`.


### PR DESCRIPTION
## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`abandoned-versions`](https://kdeldycke.github.io/repomatic/configuration.html#abandoned-versions)
- [`changelog.archive-location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-archive-location)
- [`changelog.location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-location)
- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`fix-changelog`](https://kdeldycke.github.io/repomatic/workflows.html#fix-changelog-fix-changelog)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`80b10272`](https://github.com/kdeldycke/repomatic/commit/80b10272692076612bf7b753c2bc45d16325da33)
- **Job**: [`fix-changelog`](https://github.com/kdeldycke/repomatic/blob/80b10272692076612bf7b753c2bc45d16325da33/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/80b10272692076612bf7b753c2bc45d16325da33/.github/workflows/changelog.yaml)
- **Run**: [#5097.1](https://github.com/kdeldycke/repomatic/actions/runs/31803449465)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.1.dev0`
