### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_registry.py
+++ b/repomatic/tool_registry.py
@@ -1379,7 +1379,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "bump-my-version": ToolSpec(
         name="bump-my-version",
-        version="1.5.0",
+        version="1.5.1",
         reads_pyproject=True,
         source_url="https://github.com/callowayproject/bump-my-version",
         config_docs_url="https://callowayproject.github.io/bump-my-version/reference/configuration/",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-07` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [bump-my-version](https://github.com/callowayproject/bump-my-version) | `1.5.0` → `1.5.1` | 2026-08-06 (a week ago) |

### Release notes

<details>
<summary><code>bump-my-version</code></summary>

#### [`1.5.1`](https://github.com/callowayproject/bump-my-version/releases/tag/1.5.1)

[Compare the full difference.](https://redirect.github.com/callowayproject/bump-my-version/compare/1.5.0...1.5.1)

##### New

- Add tests to cover new push on tag. [d73288a](https://redirect.github.com/callowayproject/bump-my-version/commit/d73288a8cae05be099b7bb3b484aeb9751c92fe9)

##### Other

- Document `push_tag` configuration and usage in global settings. [e832c97](https://redirect.github.com/callowayproject/bump-my-version/commit/e832c97e78075e842b5cbf7bff15f227c1bc3230)

- Support pushing tag-only releases in one go. [ec14558](https://redirect.github.com/callowayproject/bump-my-version/commit/ec14558e5fe66b0fb46732324e2c79e8a92a06bb)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.7` | `2.5.8` | 2026-08-11 (3 days ago) | 2026-08-18 (in 4 days) |
| [oxipng](https://github.com/shssoichiro/oxipng) | `10.1.1` | `10.2.0` | 2026-08-09 (5 days ago) | 2026-08-16 (in 2 days) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.27.0` | `2.27.1` | 2026-08-12 (2 days ago) | 2026-08-19 (in 5 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.1` | `0.16.2` | 2026-08-07 (a week ago) | 2026-08-14 (just now) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://kdeldycke.github.io/repomatic/workflows.html#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`c95a387e`](https://github.com/kdeldycke/repomatic/commit/c95a387e286f93ebe70fb20c452fa8353c751911)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/c95a387e286f93ebe70fb20c452fa8353c751911/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/c95a387e286f93ebe70fb20c452fa8353c751911/.github/workflows/self-maintenance.yaml)
- **Run**: [#8.1](https://github.com/kdeldycke/repomatic/actions/runs/31778195220)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.1.dev0`
