### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 
 ## [`7.12.0` (2026-08-14)](https://github.com/kdeldycke/repomatic/compare/v7.11.0...v7.12.0)
 
+> [!NOTE]
+> `7.12.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.12.0/) and [🐙 GitHub](https://github.com/kdeldycke/repomatic/releases/tag/v7.12.0).
+
 - New `ci-status` command reporting each workflow's latest run and which of its failing jobs gate a merge, read from jobs rather than run conclusions.
 - New `repomatic run <tool> --verify` reporting which files a formatter would rewrite, without touching the working tree.
 - `repomatic run` now resolves a tool's targets itself when given no arguments, and skips a tool with no matching file instead of invoking it pathless.


### PR DESCRIPTION
## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`abandoned-versions`](https://kdeldycke.github.io/repomatic/configuration.html#abandoned-versions)
- [`changelog.archive-location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-archive-location)
- [`changelog.location`](https://kdeldycke.github.io/repomatic/configuration.html#changelog-location)
- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`fix-changelog`](https://kdeldycke.github.io/repomatic/workflows.html#fix-changelog-fix-changelog)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`938cda43`](https://github.com/kdeldycke/repomatic/commit/938cda436edec3930b63cce5abfc16d23704cd63)
- **Job**: [`fix-changelog`](https://github.com/kdeldycke/repomatic/blob/938cda436edec3930b63cce5abfc16d23704cd63/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/938cda436edec3930b63cce5abfc16d23704cd63/.github/workflows/changelog.yaml)
- **Run**: [#5125.1](https://github.com/kdeldycke/repomatic/actions/runs/31844596588)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.12.1.dev0`
