### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_registry.py
+++ b/repomatic/tool_registry.py
@@ -1863,7 +1863,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "ruff": ToolSpec(
         name="ruff",
         display_name="Ruff",
-        version="0.16.1",
+        version="0.16.2",
         source_url="https://github.com/astral-sh/ruff",
         config_docs_url="https://docs.astral.sh/ruff/configuration/",
         cli_docs_url="https://docs.astral.sh/ruff/configuration/#command-line-interface",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-08` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.1` → `0.16.2` | 2026-08-07 (a week ago) |

### Release notes

<details>
<summary><code>ruff</code></summary>

#### [`0.16.2`](https://github.com/astral-sh/ruff/releases/tag/0.16.2)

##### Release Notes

Released on 2026-08-06.

###### Bug fixes

- \[`flake8-pyi`\] Avoid false positives on `singledispatch` functions (`PYI041`) ([#​27335](https://redirect.github.com/astral-sh/ruff/pull/27335))

###### Server

- Register formatting capabilities dynamically to exclude TOML files ([#​27332](https://redirect.github.com/astral-sh/ruff/pull/27332))

###### Contributors

- [@​MeGaGiGaGon](https://redirect.github.com/MeGaGiGaGon)
- [@​charliermarsh](https://redirect.github.com/charliermarsh)
- [@​epage](https://redirect.github.com/epage)
- [@​sharkdp](https://redirect.github.com/sharkdp)
- [@​ntBre](https://redirect.github.com/ntBre)

##### Install ruff 0.16.2

###### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/ruff/releases/download/0.16.2/ruff-installer.sh | sh
```

###### Install prebuilt binaries via powershell script

```sh
powershell -ExecutionPolicy Bypass -c "irm https://releases.astral.sh/github/ruff/releases/download/0.16.2/ruff-installer.ps1 | iex"
```

##### Download ruff 0.16.2

|  File  | Platform | Checksum |
|--------|----------|----------|
| [ruff-aarch64-apple-darwin.tar.gz](https://releases.astral.sh/github/ruff/releases/download/0.16.2/ruff-aarch64-apple-darwin.tar.gz) | Apple Silicon macOS | [checksum](https://releases.astral.sh/github/ruff/releases/download/0.16.2/ruff-aarch64-apple-darwin.tar.gz.sha256) |
| [ruff-x86_64-apple-darwin.tar.gz](https://releases.astral.sh/github/ruff/releases/download/0.16.2/ruff-x86_64-apple-darwin.tar.gz) | Intel macOS | [checksum](https://releases.astral.sh/github/ruff/releases/download/0.16.2/ruff-x86_64-apple-darwin.tar.gz.sha256) |
| [ruff-aarch64-pc-windows-msvc.zip](https://releases.astral.sh/github/ruff/releases/download/0.16.2/ruff-aarch64-pc-windows-msvc.zip) | ARM64 Windows | [checksum](https://releases.astral.sh/github/ruff/releases/download/0.16.2/ruff-aarch64-pc-windows-msvc.zip.sha256) |

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.16.2)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.7` | `2.5.8` | 2026-08-11 (4 days ago) | 2026-08-18 (in 3 days) |
| [mypy](https://github.com/python/mypy) | `2.3.0` | `2.3.1` | 2026-08-15 (just now) | 2026-08-22 (in a week) |
| [oxipng](https://github.com/shssoichiro/oxipng) | `10.1.1` | `10.2.0` | 2026-08-09 (6 days ago) | 2026-08-16 (in a day) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.27.0` | `2.27.1` | 2026-08-12 (3 days ago) | 2026-08-19 (in 4 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.2` | `0.16.3` | 2026-08-13 (2 days ago) | 2026-08-20 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`tool-versions.sync`](https://kdeldycke.github.io/repomatic/configuration.html#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://kdeldycke.github.io/repomatic/workflows.html#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`ff00aade`](https://github.com/kdeldycke/repomatic/commit/ff00aadef694f4b4485dcd0d6c90b53c19ee008e)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/ff00aadef694f4b4485dcd0d6c90b53c19ee008e/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/ff00aadef694f4b4485dcd0d6c90b53c19ee008e/.github/workflows/self-maintenance.yaml)
- **Run**: [#9.1](https://github.com/kdeldycke/repomatic/actions/runs/31868318007)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.12.1.dev0`
