### PR TITLE
Sync runner images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -517,6 +517,12 @@ pypi-package-history = [ "gha-utils", "repokit" ]
 # from this asset, so a release missing it breaks `/plugin install`.
 release-assets = [ "repomatic-claude-plugin.zip" ]
 
+[tool.repomatic.test-matrix]
+unstable = [{ os = "windows-11-vs2026-arm" }]
+
+[tool.repomatic.test-matrix.variations]
+os = ["windows-11-vs2026-arm"]
+
 [tool.actionlint]
 # actionlint reads no pyproject section of its own: repomatic serializes this one
 # to a temporary YAML config and passes it via `--config-file`. `paths` keys are


### PR DESCRIPTION
GitHub announced something about a runner image this repository uses. This pull request carries the mechanical half of the response; deciding whether to take it is the point of opening it rather than committing it.

| Change | What | Deadline | Announcement |
| :----- | :--- | :------- | :----------- |
| 🆕 probe | `windows-11-vs2026-arm` joins the matrix as `continue-on-error` | Thursday, June 11, 2026 | [[Windows] Windows 11 Arm with Visual Studio 2026 is now available as a public preview](https://github.com/actions/runner-images/issues/14225) |

**A 🔴 retirement moves jobs onto released ground.** The successor comes from GitHub's own available-images table, and a preview image is never chosen for it: a forced move should not trade a known deadline for an unknown one.

**A 🆕 probe changes nothing you depend on.** The image joins the full test matrix as a `continue-on-error` cell, so it cannot fail the build. The point is to start exercising it now: a dependency that breaks on a new image surfaces here months before the image is one you have to be on, while there is still time to report it upstream.

> [!IMPORTANT]
> The CI run on this pull request is the evidence. Read it before merging, and check `repomatic job-timings` for what the image costs in whole-job wall-clock, not just whether it passes.

To decline a proposal permanently, name the label in `pyproject.toml` rather than closing this pull request, which only brings it back on the next push:

```toml
[tool.repomatic.sync-runner-images]
ignore = ["the-label"]
```

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.0.dev0`



> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-runner-images`](https://kdeldycke.github.io/repomatic/workflows.html#sync-runner-images-sync-runner-images)
- **Trigger**: `workflow_dispatch`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`a3c7f402`](https://github.com/kdeldycke/repomatic/commit/a3c7f402d5aaaa1a52d06c0bbdbbc395c8147010)
- **Job**: [`sync-runner-images`](https://github.com/kdeldycke/repomatic/blob/a3c7f402d5aaaa1a52d06c0bbdbbc395c8147010/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/a3c7f402d5aaaa1a52d06c0bbdbbc395c8147010/.github/workflows/autofix.yaml)
- **Run**: [#5351.1](https://github.com/kdeldycke/repomatic/actions/runs/31896019097)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.0.dev0`
