### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_registry.py
+++ b/repomatic/tool_registry.py
@@ -1137,23 +1137,23 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "a69c9dbb110463746153bf9b56488a293747e1d90dc1f30d24af3d9615165b98",
+        ): "97d168c6c0d1dbcb36e7438eb489804748a2ba40d94fe21aa7dab7372e9efe9b",
         (
             LINUX,
             X86_64,
-        ): "5988392e88fc3d03f562f2d565e5c12a095223ae8bd983576f2aaff2fadf3738",
+        ): "b33f84c73d42cb592bea5d84c431030b1e97784817693380dfcec7d9575f871e",
         (
             MACOS,
             AARCH64,
-        ): "615a401629b5cc104bdc775ac962abd67ab2f3084f0b3b1ba9c51e9b76c3964f",
+        ): "9aad3927d095b6ade2aacb92b89ebaca442483c1f7cde5d7a2486b283c2ed5f9",
         (
             MACOS,
             X86_64,
-        ): "8f23d1bc9cd5b3f88e84f1cca77b461f6900aa20f2ecbf84f729cd12530c5a53",
+        ): "c45acf40a70cc02539c55555ac240bf5ef24544b7ea9959d22da19f606cec205",
         (
             WINDOWS,
             X86_64,
-        ): "0f57b33abb46c76258ac8e20be604a48208141d514bc2936b5200ed626976dd8",
+        ): "a5ad52c9c288dc99c2eae90dcad73dee64e39bf3f5aa5303c0fb55ac9c5f069b",
     },
     "shfmt": {
         (
@@ -1215,7 +1215,7 @@ VERSIONS: dict[str, str] = {
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
     "lychee": "0.24.2",
-    "oxipng": "10.1.1",
+    "oxipng": "10.2.0",
     "shfmt": "3.13.1",
     "typos": "1.49.0",
 }
@@ -1786,7 +1786,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "oxipng": ToolSpec(
         name="oxipng",
         display_name="Oxipng",
-        version="10.1.1",
+        version="10.2.0",
         source_url="https://github.com/shssoichiro/oxipng",
         cli_docs_url="https://github.com/shssoichiro/oxipng#usage",
         binary=BinarySpec(


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-10` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [oxipng](https://github.com/shssoichiro/oxipng) | `10.1.1` → `10.2.0` | 2026-08-09 (a week ago) |

### Release notes

<details>
<summary><code>oxipng</code></summary>

#### [`v10.2.0`](https://github.com/shssoichiro/oxipng/releases/tag/v10.2.0)

- [Performance] Improve performance of filtering and reductions.
- [Improvement] Balance changes to level presets for better/faster results.
- [Improvement] Improve optimization of indexed images.
- [Improvement] Slightly improve optimization of interlaced images.
- [Improvement] Make `--keep` more robust, no longer stripping certain chunks regardless.
- [Misc] Show oxipng version in verbose output.
- [Misc] Bump minimum Rust version to 1.88.0.

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.7` | `2.5.8` | 2026-08-11 (6 days ago) | 2026-08-18 (in a day) |
| [mypy](https://github.com/python/mypy) | `2.3.0` | `2.3.1` | 2026-08-15 (2 days ago) | 2026-08-22 (in 5 days) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.27.0` | `2.28.0` | 2026-08-16 (a day ago) | 2026-08-23 (in 6 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.2` | `0.16.3` | 2026-08-13 (4 days ago) | 2026-08-20 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`tool-versions.sync`](https://repomatic.net/configuration#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://repomatic.net/workflows#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`82a7c574`](https://github.com/kdeldycke/repomatic/commit/82a7c5744392557ba59cc6618fd5774506316098)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/82a7c5744392557ba59cc6618fd5774506316098/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/82a7c5744392557ba59cc6618fd5774506316098/.github/workflows/self-maintenance.yaml)
- **Run**: [#11.1](https://github.com/kdeldycke/repomatic/actions/runs/32000196495)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.0.dev0`
