### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tool_registry.py
+++ b/repomatic/tool_registry.py
@@ -1036,27 +1036,27 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "27490d47af66420788b634afb48db23b588f272c8a284ba3daf706a5faa640ab",
+        ): "bf593f7955e3a437fb8056b255142b50872baa3e81371cda2c3fce9239af1890",
         (
             LINUX,
             X86_64,
-        ): "7b5045d6d34f055df8ffe1bf3077164e6f6a24c45a41497d628a5e86d0e12fe7",
+        ): "013eb5158b9e53235dbbf31255cb3b776fb9338b32fa6ff4a44ee1ceed65ee63",
         (
             MACOS,
             AARCH64,
-        ): "f71fe80909d2f70f1e051320f5ba9dfd553bc5ef3bacef5cdee1b00ee96a285c",
+        ): "7d8b51dec857ffa8aa35ce5eaa3a4476cd62bed013adc2896bf43cac0a67a79b",
         (
             MACOS,
             X86_64,
-        ): "887431b79e45758e05d94a89111af72b28e5d6545c92480ecac9247d8bacb321",
+        ): "df2b50ee283634cdd6f7570b7da06bc3c9cd7ec0590ecbbaf986c7590bef3289",
         (
             WINDOWS,
             AARCH64,
-        ): "655cc1f2ecf3719f79c9def7f2d824bb2a451fcd1d738d43468b12dd66620fd5",
+        ): "d6845ff075043300551d4ad74985814e4e4c56b49ffa87b3724ddf5055a2efe9",
         (
             WINDOWS,
             X86_64,
-        ): "62adea0ea523f04cc5c074b2bb00e748b97252023aede03196e1bf4aacf80a9c",
+        ): "f8474a0f9f457df176c10be3f0e82be890e8986ff2805d4a7f3c5a4cba5962ca",
     },
     "gh": {
         (
@@ -1227,7 +1227,7 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
-    "biome": "2.5.7",
+    "biome": "2.5.9",
     "gh": "2.97.0",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
@@ -1354,7 +1354,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         ),
         default_paths="json_files",
         display_name="Biome",
-        version="2.5.7",
+        version="2.5.9",
         source_url="https://github.com/biomejs/biome",
         tag_pattern=r"^@biomejs/biome@(?P<version>.+)$",
         config_docs_url="https://biomejs.dev/reference/configuration/",
@@ -1720,7 +1720,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "mypy": ToolSpec(
         name="mypy",
         default_paths="python_files",
-        version="2.3.0",
+        version="2.3.1",
         source_url="https://github.com/python/mypy",
         config_docs_url="https://mypy.readthedocs.io/en/stable/config_file.html",
         cli_docs_url="https://mypy.readthedocs.io/en/stable/command_line.html",
@@ -1848,7 +1848,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "pyproject-fmt": ToolSpec(
         name="pyproject-fmt",
         default_paths="pyproject_files",
-        version="2.27.0",
+        version="2.28.0",
         source_url="https://github.com/tox-dev/pyproject-fmt",
         config_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
         cli_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
@@ -1877,7 +1877,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "ruff": ToolSpec(
         name="ruff",
         display_name="Ruff",
-        version="0.16.2",
+        version="0.16.3",
         source_url="https://github.com/astral-sh/ruff",
         config_docs_url="https://docs.astral.sh/ruff/configuration/",
         cli_docs_url="https://docs.astral.sh/ruff/configuration/#command-line-interface",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-18` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.7` → `2.5.9` | 2026-08-17 (a week ago) |
| [mypy](https://github.com/python/mypy) | `2.3.0` → `2.3.1` | 2026-08-15 (a week ago) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.27.0` → `2.28.0` | 2026-08-16 (a week ago) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.2` → `0.16.3` | 2026-08-13 (a week ago) |

### Release notes

<details>
<summary><code>biome</code></summary>

#### [`@biomejs/biome@2.5.8`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.8)

##### 2.5.8

###### Patch Changes

- [#​10710](https://redirect.github.com/biomejs/biome/pull/10710) [`0a0fbc1`](https://redirect.github.com/biomejs/biome/commit/0a0fbc15d67c410c80dfae398903f845544fcd65) Thanks [@​dyc3](https://redirect.github.com/dyc3)! - Added a new nursery rule [`useReactCompiler`](https://biomejs.dev/linter/rules/use-react-compiler/), which reports diagnostics from React Compiler lint mode.

- [#​11251](https://redirect.github.com/biomejs/biome/pull/11251) [`ea9dd8a`](https://redirect.github.com/biomejs/biome/commit/ea9dd8a93e65f849840415e8e26cd668aa1af913) Thanks [@​dyc3](https://redirect.github.com/dyc3)! - Improved performance of [`noImportCycles`](https://biomejs.dev/linter/rules/no-import-cycles/).

- [#​11247](https://redirect.github.com/biomejs/biome/pull/11247) [`52b44d6`](https://redirect.github.com/biomejs/biome/commit/52b44d6795741d051bf703bd69c6cb447af8fd1d) Thanks [@​dyc3](https://redirect.github.com/dyc3)! - Added the nursery rule [`noSvelteLegacyConst`](https://biomejs.dev/linter/rules/no-svelte-legacy-const/), which disallows legacy Svelte `{@const}` tags and recommends declaration tags with `$derived()`.

  Invalid:

  ```svelte
  {#each boxes as box}
    {@const area = box.width * box.height}
    <p>{area}</p>
  {/each}
  ```

  Valid:

  ```svelte
  {#each boxes as box}
    {const area = $derived(box.width * box.height)}
    <p>{area}</p>
  {/each}
  ```

- [#​11252](https://redirect.github.com/biomejs/biome/pull/11252) [`d5f5704`](https://redirect.github.com/biomejs/biome/commit/d5f570414fdcdddf62372e35c05f6dababad9287) Thanks [@​Turtle-Hwan](https://redirect.github.com/Turtle-Hwan)! - Fixed [#​11250](https://redirect.github.com/biomejs/biome/issues/11250): [`useAwait`](https://biomejs.dev/linter/rules/use-await/) no longer reports async functions that contain an `await using` declaration.

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.8)

#### [`@biomejs/biome@2.5.9`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.9)

##### 2.5.9

###### Patch Changes

- [#​11321](https://redirect.github.com/biomejs/biome/pull/11321) [`41386f3`](https://redirect.github.com/biomejs/biome/commit/41386f38935b299f1a1f759a2c7fdd5c2050bded) Thanks [@​dyc3](https://redirect.github.com/dyc3)! - Fixed [#​11315](https://redirect.github.com/biomejs/biome/issues/11315): The CSS parser now recovers at declaration boundaries after bogus declarations, allowing subsequent valid declarations to be parsed.

- [#​11248](https://redirect.github.com/biomejs/biome/pull/11248) [`57b197e`](https://redirect.github.com/biomejs/biome/commit/57b197e6d5a2432ff6904afff24125e4d8ec01cd) Thanks [@​yanthomasdev](https://redirect.github.com/yanthomasdev)! - Expanded the environment variable metadata used by `biome rage` to include `BIOME_BINARY`, `BIOME_LOG_FILE`, and `RUST_BACKTRACE` as well as reworded explanations for better readability.

- [#​11377](https://redirect.github.com/biomejs/biome/pull/11377) [`a8798ea`](https://redirect.github.com/biomejs/biome/commit/a8798ea9f2569fab4524704c99a8e2fe45c2ca32) Thanks [@​Netail](https://redirect.github.com/Netail)! - Added a new nursery rule [`useNamedLayer`](https://biomejs.dev/linter/rules/use-named-layer) which disallows anonymous cascade layers.

  ```css
  @layer {
    a {
      color: red;
    }
  }
  ```

- [#​11327](https://redirect.github.com/biomejs/biome/pull/11327) [`6771cf5`](https://redirect.github.com/biomejs/biome/commit/6771cf5bd2e64f256468a33b811adec8e793d933) Thanks [@​dyc3](https://redirect.github.com/dyc3)! - The HTML formatter now preserves meaningful blank lines in HTML, including spacing after elements with trailing spaces and blank lines between comment groups.

  ```diff
   <div>
     <!-- first group -->
  +
     <!-- second group -->
   </div>
  ```

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.9)

</details>

<details>
<summary><code>pyproject-fmt</code></summary>

#### [`v2.27.1`](https://github.com/tox-dev/pyproject-fmt/releases/tag/v2.27.1)

<!-- Release notes generated using configuration in .github/release.yaml at v2.27.1 -->

**Full Changelog**: https://redirect.github.com/tox-dev/pyproject-fmt/compare/v2.27.0...v2.27.1

#### [`v2.28.0`](https://github.com/tox-dev/pyproject-fmt/releases/tag/v2.28.0)

<!-- Release notes generated using configuration in .github/release.yaml at v2.28.0 -->

**Full Changelog**: https://redirect.github.com/tox-dev/pyproject-fmt/compare/v2.27.1...v2.28.0

</details>

<details>
<summary><code>ruff</code></summary>

#### [`0.16.3`](https://github.com/astral-sh/ruff/releases/tag/0.16.3)

##### Release Notes

Released on 2026-08-13.

###### Preview features

- \[`pylint`\] Fix false negatives on negative numbers (`PLR6104`) ([#​27251](https://redirect.github.com/astral-sh/ruff/pull/27251))
- \[`pyupgrade`\] Add rule to replace `while 1` with `while True` (`UP048`) ([#​27190](https://redirect.github.com/astral-sh/ruff/pull/27190))

###### Bug fixes

- \[`flake8-bandit`\] Also check keyword arguments (`S602`, `S603`, `S607`, `S609`) ([#​27687](https://redirect.github.com/astral-sh/ruff/pull/27687))
- \[`pylint`\] Allow `continue` in `finally` on Python 3.8 ([#​27626](https://redirect.github.com/astral-sh/ruff/pull/27626))
- \[`pylint`\] Fix `PLE1307` false positive with bools ([#​27651](https://redirect.github.com/astral-sh/ruff/pull/27651))
- \[`pylint`\] Fix false positives and negatives with `%b` format character (`PLE1300`, `PLE1307`) ([#​27560](https://redirect.github.com/astral-sh/ruff/pull/27560))
- \[`pylint`\] Improve handling of concatenated strings (`PLE1300`) ([#​27659](https://redirect.github.com/astral-sh/ruff/pull/27659))

###### Rule changes

- \[`numpy`\] Make `np.chararray` autofix backwards-compatible (`NPY201`) ([#​27527](https://redirect.github.com/astral-sh/ruff/pull/27527))

###### Performance

- Enable PGO for Linux x86-64 Ruff releases ([#​27570](https://redirect.github.com/astral-sh/ruff/pull/27570))
- Enable PGO for Linux ARM64 Ruff releases ([#​27574](https://redirect.github.com/astral-sh/ruff/pull/27574))
- Enable PGO for Windows x86-64 Ruff releases ([#​27573](https://redirect.github.com/astral-sh/ruff/pull/27573))
- Enable PGO for macOS ARM64 Ruff releases ([#​27572](https://redirect.github.com/astral-sh/ruff/pull/27572))
- Reduce `Expr` size to 64 bytes ([#​27591](https://redirect.github.com/astral-sh/ruff/pull/27591))

###### CLI

- Hyperlink rule codes in `ruff check --statistics` output ([#​27646](https://redirect.github.com/astral-sh/ruff/pull/27646))

###### Documentation

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.16.3)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.9` | `2.5.10` | 2026-08-21 (4 days ago) | 2026-08-28 (in 3 days) |
| [gh](https://github.com/cli/cli) | `2.97.0` | `2.98.0` | 2026-08-20 (5 days ago) | 2026-08-27 (in 2 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.3` | `0.16.4` | 2026-08-20 (5 days ago) | 2026-08-27 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`tool-versions.sync`](https://repomatic.net/configuration#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://repomatic.net/workflows#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`0d6a8132`](https://github.com/kdeldycke/repomatic/commit/0d6a81325bfa32c3d2d970a9c0eccb40d669f20d)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/0d6a81325bfa32c3d2d970a9c0eccb40d669f20d/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/0d6a81325bfa32c3d2d970a9c0eccb40d669f20d/.github/workflows/self-maintenance.yaml)
- **Run**: [#19.1](https://github.com/kdeldycke/repomatic/actions/runs/32815297879)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.1.dev0`
