### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -210,7 +210,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.8.1'
+          uvx --no-progress 'click-extra==8.9.1'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -249,7 +249,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.8.1' prebake all
+        run: uvx --no-progress 'click-extra==8.9.1' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -235,7 +235,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
         run: >
-          npx --yes wrangler@4.122.0 pages deploy ./docs/_build
+          npx --yes wrangler@4.123.0 pages deploy ./docs/_build
           --project-name "$PROJECT_NAME"
           --branch "$REF_NAME"
           --commit-hash "$COMMIT_SHA"


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-18` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.8.1` → `8.9.1` | 2026-08-15 (a week ago) |
| [wrangler](https://www.npmjs.com/package/wrangler) | `4.122.0` → `4.123.0` | 2026-08-13 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.9.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.9.0)

> [!NOTE]
> `8.9.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.9.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.9.0).

- Add a `transform` argument to `EnumChoice`, reshaping the string produced by any choice source, so `show_aliases` can spell aliases in kebab-case instead of raw Python identifiers.
- Reject a `transform` collapsing two `EnumChoice` members into the same choice string, instead of silently dropping one from the help screen.
- Point the `EnumChoice` `show_aliases` error at `transform` and explain why `ChoiceSource.STR` and callable sources cannot see aliases.
- Add a `max_column_widths` argument to `render_table()` and `print_table()`, and a `max_width` field to `ColumnSpec`, capping a column to a character count or to `auto`.
- Wrap long cells in the `vertical` format, aligning continuation lines under the label gutter.
- Add a `WRAPPABLE_FORMATS` registry and a `TableFormat.is_wrappable` property, so formats unable to render a wrapped cell drop column widths instead of corrupting their output.
- Add `wrap_ansi()`, wrapping a string to a visible width without counting its ANSI escapes toward the line length, and keeping each line's styling self-contained.
- Read the input of `run_jobs()` and `run_lanes()` lazily, keeping a bounded window of tasks in flight instead of materializing the whole stream.
- Stop scheduling the rest of a `run_jobs()` or `run_lanes()` stream when the caller breaks early, at any worker count and not only at `--jobs 1`.
- Declare `run_jobs()` and `run_lanes()` as generators, so the early-exit `close()` they document is visible to type checkers.
- Render the `{matrix} python` axis in three states: `✅` for a version a release declares, `❌` for one its `requires-python` rules out, and `–` for one it neither claimed nor forbade.
- Split a Python matrix row when the declared `requires-python` changes, even if the set of supported versions does not.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.9.0)

#### [`v8.9.1`](https://github.com/kdeldycke/click-extra/releases/tag/v8.9.1)

> [!NOTE]
> `8.9.1` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.9.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.9.1).

- Fix the man-page links of the `click-extra-manpages` directive, which pointed one directory too high on `dirhtml` and `singlehtml` builds.
- Resolve man-page links against each rendered page, so they stay correct when builders share a doctree cache.
- Stop resolving man-page links through a Sphinx API deprecated for removal in Sphinx 11.
- Document the `colon-grid` table format.
- Fix the Sphinx page's `click:run` example, which reported the documentation build's own Sphinx version instead of the CLI's.

**Full changelog**: [`v8.9.0...v8.9.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.9.0...v8.9.1)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [wrangler](https://www.npmjs.com/package/wrangler) | `4.123.0` | `4.125.0` | 2026-08-20 (5 days ago) | 2026-08-27 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`workflow-pins.sync`](https://repomatic.net/configuration#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://repomatic.net/workflows#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`0d6a8132`](https://github.com/kdeldycke/repomatic/commit/0d6a81325bfa32c3d2d970a9c0eccb40d669f20d)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/0d6a81325bfa32c3d2d970a9c0eccb40d669f20d/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/0d6a81325bfa32c3d2d970a9c0eccb40d669f20d/.github/workflows/autofix.yaml)
- **Run**: [#5416.1](https://github.com/kdeldycke/repomatic/actions/runs/32815229311)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.1.dev0`
